### PR TITLE
#87: 권한에 따른 엔드포인트 인가 처리

### DIFF
--- a/src/main/java/edu/handong/csee/histudy/config/SwaggerConfig.java
+++ b/src/main/java/edu/handong/csee/histudy/config/SwaggerConfig.java
@@ -1,5 +1,6 @@
 package edu.handong.csee.histudy.config;
 
+import edu.handong.csee.histudy.domain.Role;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.security.SecurityScheme;
@@ -10,28 +11,35 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class SwaggerConfig {
 
-    @Value("${custom.jwt.secret.general}")
-    private String generalToken;
+    @Value("${custom.jwt.secret.user}")
+    private String userToken;
+
+    @Value("${custom.jwt.secret.member}")
+    private String memberToken;
 
     @Value("${custom.jwt.secret.admin}")
     private String adminToken;
 
     @Bean
     public OpenAPI customizeOpenAPI() {
-        String general = "General";
-        String admin = "Admin";
-
         return new OpenAPI()
                 .components(new Components()
-                        .addSecuritySchemes(general, new SecurityScheme()
-                                .name(general)
-                                .description("For general user testing, use the following token:\n\n"
-                                        + generalToken)
+                        .addSecuritySchemes(Role.USER.name(), new SecurityScheme()
+                                .name(Role.USER.name())
+                                .description("For user testing, use the following token:\n\n"
+                                        + userToken)
                                 .type(SecurityScheme.Type.HTTP)
                                 .scheme("bearer")
                                 .bearerFormat("JWT"))
-                        .addSecuritySchemes(admin, new SecurityScheme()
-                                .name(admin)
+                        .addSecuritySchemes(Role.MEMBER.name(), new SecurityScheme()
+                                .name(Role.MEMBER.name())
+                                .description("For member testing, use the following token:\n\n"
+                                        + memberToken)
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT"))
+                        .addSecuritySchemes(Role.ADMIN.name(), new SecurityScheme()
+                                .name(Role.ADMIN.name())
                                 .description("For administrator testing, use the following token:\n\n"
                                         + adminToken)
                                 .type(SecurityScheme.Type.HTTP)

--- a/src/main/java/edu/handong/csee/histudy/controller/AdminController.java
+++ b/src/main/java/edu/handong/csee/histudy/controller/AdminController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @Tag(name = "관리자 API")
-@SecurityRequirement(name = "Admin")
+@SecurityRequirement(name = "ADMIN")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/admin")

--- a/src/main/java/edu/handong/csee/histudy/controller/AdminController.java
+++ b/src/main/java/edu/handong/csee/histudy/controller/AdminController.java
@@ -1,9 +1,11 @@
 package edu.handong.csee.histudy.controller;
 
+import edu.handong.csee.histudy.domain.Role;
 import edu.handong.csee.histudy.dto.TeamDto;
 import edu.handong.csee.histudy.dto.TeamIdDto;
 import edu.handong.csee.histudy.dto.TeamReportDto;
 import edu.handong.csee.histudy.dto.UserDto;
+import edu.handong.csee.histudy.exception.ForbiddenException;
 import edu.handong.csee.histudy.service.TeamService;
 import edu.handong.csee.histudy.service.UserService;
 import io.jsonwebtoken.Claims;
@@ -26,16 +28,26 @@ public class AdminController {
     private final TeamService teamService;
     private final UserService userService;
 
-    @Operation(summary = "매칭된 그룹 목록 조회")
+    @Operation(summary = "그룹별 활동 조회")
     @GetMapping(value = "/manageGroup")
     public ResponseEntity<List<TeamDto>> getTeams(@RequestAttribute Claims claims) {
-        return ResponseEntity.ok(teamService.getTeams(claims.getSubject()));
+        if (Role.isAuthorized(claims, Role.ADMIN)) {
+            String email = claims.getSubject();
+            return ResponseEntity.ok(teamService.getTeams(email));
+        }
+        throw new ForbiddenException();
     }
 
+    @Deprecated
     @Operation(summary = "그룹 삭제")
     @DeleteMapping("/group")
-    public ResponseEntity<Integer> deleteTeam(@RequestBody TeamIdDto dto, @RequestAttribute Claims claims) {
-        return ResponseEntity.ok(teamService.deleteTeam(dto, claims.getSubject()));
+    public ResponseEntity<Integer> deleteTeam(
+            @RequestBody TeamIdDto dto,
+            @RequestAttribute Claims claims) {
+        if (Role.isAuthorized(claims, Role.ADMIN)) {
+            return ResponseEntity.ok(teamService.deleteTeam(dto, claims.getSubject()));
+        }
+        throw new ForbiddenException();
     }
 
     @Operation(summary = "특정 그룹 보고서 조회")
@@ -44,36 +56,58 @@ public class AdminController {
             @Parameter(description = "그룹 아이디", required = true)
             @PathVariable(name = "id") long id,
             @RequestAttribute Claims claims) {
-        return ResponseEntity.ok(teamService.getTeamReports(id, claims.getSubject()));
+        if (Role.isAuthorized(claims, Role.ADMIN)) {
+            return ResponseEntity.ok(teamService.getTeamReports(id, claims.getSubject()));
+        }
+        throw new ForbiddenException();
     }
 
     @Operation(summary = "신청한 유저 목록 조회")
     @GetMapping("/allUsers")
-    public ResponseEntity<List<UserDto.UserInfo>> getAppliedUsers() {
-        return ResponseEntity.ok(userService.getAppliedUsers());
+    public ResponseEntity<List<UserDto.UserInfo>> getAppliedUsers(@RequestAttribute Claims claims) {
+        if (Role.isAuthorized(claims, Role.ADMIN)) {
+            return ResponseEntity.ok(userService.getAppliedUsers());
+        }
+        throw new ForbiddenException();
     }
 
     @Operation(summary = "그룹 매칭")
     @PostMapping("/team-match")
-    public ResponseEntity<TeamDto.MatchResults> matchTeam() {
-        return ResponseEntity.ok(teamService.matchTeam());
+    public ResponseEntity<TeamDto.MatchResults> matchTeam(@RequestAttribute Claims claims) {
+        if (Role.isAuthorized(claims, Role.ADMIN)) {
+            return ResponseEntity.ok(teamService.matchTeam());
+        }
+        throw new ForbiddenException();
     }
 
     @Operation(summary = "매칭되지 않은 유저 목록 조회")
     @GetMapping("/unmatched-users")
-    public ResponseEntity<List<UserDto.UserInfo>> getUnmatchedUsers() {
-        return ResponseEntity.ok(userService.getUnmatchedUsers());
+    public ResponseEntity<List<UserDto.UserInfo>> getUnmatchedUsers(@RequestAttribute Claims claims) {
+        if (Role.isAuthorized(claims, Role.ADMIN)) {
+            return ResponseEntity.ok(userService.getUnmatchedUsers());
+        }
+        throw new ForbiddenException();
     }
 
     @Operation(summary = "특정 유저 지원폼 삭제")
     @DeleteMapping("/form")
-    public UserDto.UserInfo deleteForm(@RequestParam String sid) {
-        return userService.deleteUserForm(sid);
+    public UserDto.UserInfo deleteForm(
+            @RequestParam String sid,
+            @RequestAttribute Claims claims) {
+        if (Role.isAuthorized(claims, Role.ADMIN)) {
+            return userService.deleteUserForm(sid);
+        }
+        throw new ForbiddenException();
     }
 
     @Operation(summary = "유저 정보 수정")
     @PostMapping("/edit-user")
-    public UserDto.UserInfo editUser(@RequestBody UserDto.UserEdit dto) {
-        return userService.editUser(dto);
+    public UserDto.UserInfo editUser(
+            @RequestBody UserDto.UserEdit dto,
+            @RequestAttribute Claims claims) {
+        if (Role.isAuthorized(claims, Role.ADMIN)) {
+            return userService.editUser(dto);
+        }
+        throw new ForbiddenException();
     }
 }

--- a/src/main/java/edu/handong/csee/histudy/controller/ApplyFormController.java
+++ b/src/main/java/edu/handong/csee/histudy/controller/ApplyFormController.java
@@ -13,7 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "스터디 신청 API")
-@SecurityRequirement(name = "General")
+@SecurityRequirement(name = "USER")
 @RestController
 @RequestMapping("/api/forms")
 @RequiredArgsConstructor

--- a/src/main/java/edu/handong/csee/histudy/controller/ApplyFormController.java
+++ b/src/main/java/edu/handong/csee/histudy/controller/ApplyFormController.java
@@ -1,7 +1,9 @@
 package edu.handong.csee.histudy.controller;
 
 import edu.handong.csee.histudy.controller.form.ApplyForm;
+import edu.handong.csee.histudy.domain.Role;
 import edu.handong.csee.histudy.dto.ApplyFormDto;
+import edu.handong.csee.histudy.exception.ForbiddenException;
 import edu.handong.csee.histudy.service.UserService;
 import io.jsonwebtoken.Claims;
 import io.swagger.v3.oas.annotations.Operation;
@@ -23,10 +25,14 @@ public class ApplyFormController {
 
     @Operation(summary = "스터디 신청")
     @PostMapping
-    public ResponseEntity<ApplyFormDto> applyForStudy(@RequestBody ApplyForm form,
-                                                      @RequestAttribute Claims claims) {
-        return userService.apply(form, claims.getSubject())
-                .map(ResponseEntity::ok)
-                .orElse(ResponseEntity.status(HttpStatus.BAD_REQUEST).build());
+    public ResponseEntity<ApplyFormDto> applyForStudy(
+            @RequestBody ApplyForm form,
+            @RequestAttribute Claims claims) {
+        if (Role.isAuthorized(claims, Role.USER)) {
+            return userService.apply(form, claims.getSubject())
+                    .map(ResponseEntity::ok)
+                    .orElse(ResponseEntity.status(HttpStatus.BAD_REQUEST).build());
+        }
+        throw new ForbiddenException();
     }
 }

--- a/src/main/java/edu/handong/csee/histudy/controller/AuthController.java
+++ b/src/main/java/edu/handong/csee/histudy/controller/AuthController.java
@@ -38,13 +38,14 @@ public class AuthController {
 
         if (userOr.isPresent()) {
             User user = userOr.get();
-            JwtPair tokens = jwtService.issueToken(user.getEmail(), user.getName());
+            JwtPair tokens = jwtService.issueToken(user.getEmail(), user.getName(), user.getRole());
 
             return ResponseEntity.ok(
                     UserDto.UserLogin.builder()
                             .isRegistered(true)
                             .tokenType("Bearer ")
                             .tokens(tokens)
+                            .role(user.getRole().name())
                             .build());
         }
         return ResponseEntity
@@ -68,9 +69,7 @@ public class AuthController {
                     .build();
         }
         Claims claims = claimsOr.get();
-        String email = claims.getSubject();
-        String name = claims.get("name", String.class);
-        String accessToken = jwtService.issueToken(email, name, GrantType.ACCESS_TOKEN);
+        String accessToken = jwtService.issueToken(claims, GrantType.ACCESS_TOKEN);
 
         return ResponseEntity.ok(new TokenInfo(GrantType.ACCESS_TOKEN, accessToken));
     }

--- a/src/main/java/edu/handong/csee/histudy/controller/CourseController.java
+++ b/src/main/java/edu/handong/csee/histudy/controller/CourseController.java
@@ -24,7 +24,7 @@ public class CourseController {
 
     private final CourseService courseService;
 
-    @SecurityRequirement(name = "Admin")
+    @SecurityRequirement(name = "ADMIN")
     @Operation(summary = "강의 목록 업로드")
     @PostMapping
     public ResponseEntity<String> importCourses(@RequestParam("file") MultipartFile file) throws IOException {
@@ -43,7 +43,7 @@ public class CourseController {
         }
     }
 
-    @SecurityRequirement(name = "Admin")
+    @SecurityRequirement(name = "ADMIN")
     @Operation(summary = "강의 삭제")
     @PostMapping("/delete")
     public int deleteCourse(@RequestBody CourseIdDto dto) {
@@ -51,8 +51,8 @@ public class CourseController {
     }
 
     @SecurityRequirements({
-            @SecurityRequirement(name = "Admin"),
-            @SecurityRequirement(name = "General")
+            @SecurityRequirement(name = "ADMIN"),
+            @SecurityRequirement(name = "USER")
     })
     @Operation(summary = "강의 목록 조회")
     @GetMapping

--- a/src/main/java/edu/handong/csee/histudy/controller/CourseController.java
+++ b/src/main/java/edu/handong/csee/histudy/controller/CourseController.java
@@ -1,8 +1,11 @@
 package edu.handong.csee.histudy.controller;
 
+import edu.handong.csee.histudy.domain.Role;
 import edu.handong.csee.histudy.dto.CourseDto;
 import edu.handong.csee.histudy.dto.CourseIdDto;
+import edu.handong.csee.histudy.exception.ForbiddenException;
 import edu.handong.csee.histudy.service.CourseService;
+import io.jsonwebtoken.Claims;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.security.SecurityRequirements;
@@ -27,27 +30,37 @@ public class CourseController {
     @SecurityRequirement(name = "ADMIN")
     @Operation(summary = "강의 목록 업로드")
     @PostMapping
-    public ResponseEntity<String> importCourses(@RequestParam("file") MultipartFile file) throws IOException {
-        if (file.isEmpty()) {
-            return ResponseEntity
-                    .status(HttpStatus.NOT_ACCEPTABLE)
-                    .body("Empty file");
-        } else {
-            String status = courseService.uploadFile(file);
-            if (status.equals("FAILED"))
+    public ResponseEntity<String> importCourses(
+            @RequestParam("file") MultipartFile file,
+            @RequestAttribute Claims claims) throws IOException {
+        if (Role.isAuthorized(claims, Role.ADMIN)) {
+            if (file.isEmpty()) {
                 return ResponseEntity
-                        .status(HttpStatus.INTERNAL_SERVER_ERROR)
-                        .body("Failed in server");
-            else
-                return ResponseEntity.ok(status);
+                        .status(HttpStatus.NOT_ACCEPTABLE)
+                        .body("Empty file");
+            } else {
+                String status = courseService.uploadFile(file);
+                if (status.equals("FAILED"))
+                    return ResponseEntity
+                            .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                            .body("Failed in server");
+                else
+                    return ResponseEntity.ok(status);
+            }
         }
+        throw new ForbiddenException();
     }
 
     @SecurityRequirement(name = "ADMIN")
     @Operation(summary = "강의 삭제")
     @PostMapping("/delete")
-    public int deleteCourse(@RequestBody CourseIdDto dto) {
-        return courseService.deleteCourse(dto);
+    public int deleteCourse(
+            @RequestBody CourseIdDto dto,
+            @RequestAttribute Claims claims) {
+        if (Role.isAuthorized(claims, Role.ADMIN)) {
+            return courseService.deleteCourse(dto);
+        }
+        throw new ForbiddenException();
     }
 
     @SecurityRequirements({
@@ -56,11 +69,16 @@ public class CourseController {
     })
     @Operation(summary = "강의 목록 조회")
     @GetMapping
-    public ResponseEntity<CourseDto> getCourses(@RequestParam(name = "search", required = false) String keyword) {
-        List<CourseDto.CourseInfo> courses = (keyword == null)
-                ? courseService.getCourses()
-                : courseService.search(keyword);
+    public ResponseEntity<CourseDto> getCourses(
+            @RequestParam(name = "search", required = false) String keyword,
+            @RequestAttribute Claims claims) {
+        if (Role.isAuthorized(claims, Role.ADMIN, Role.USER)) {
+            List<CourseDto.CourseInfo> courses = (keyword == null)
+                    ? courseService.getCourses()
+                    : courseService.search(keyword);
 
-        return ResponseEntity.ok(new CourseDto(courses));
+            return ResponseEntity.ok(new CourseDto(courses));
+        }
+        throw new ForbiddenException();
     }
 }

--- a/src/main/java/edu/handong/csee/histudy/controller/ExceptionController.java
+++ b/src/main/java/edu/handong/csee/histudy/controller/ExceptionController.java
@@ -1,0 +1,24 @@
+package edu.handong.csee.histudy.controller;
+
+import edu.handong.csee.histudy.dto.ExceptionResponse;
+import edu.handong.csee.histudy.exception.ForbiddenException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Arrays;
+
+@RestControllerAdvice
+public class ExceptionController {
+
+    @ExceptionHandler(ForbiddenException.class)
+    public ResponseEntity<ExceptionResponse> forbidden(ForbiddenException e) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                .body(ExceptionResponse.builder()
+                        .status(HttpStatus.FORBIDDEN)
+                        .message(e.getMessage())
+                        .trace(Arrays.toString(e.getStackTrace()))
+                        .build());
+    }
+}

--- a/src/main/java/edu/handong/csee/histudy/controller/TeamController.java
+++ b/src/main/java/edu/handong/csee/histudy/controller/TeamController.java
@@ -1,9 +1,11 @@
 package edu.handong.csee.histudy.controller;
 
 import edu.handong.csee.histudy.controller.form.ReportForm;
+import edu.handong.csee.histudy.domain.Role;
 import edu.handong.csee.histudy.dto.CourseDto;
 import edu.handong.csee.histudy.dto.ReportDto;
 import edu.handong.csee.histudy.dto.UserDto;
+import edu.handong.csee.histudy.exception.ForbiddenException;
 import edu.handong.csee.histudy.service.CourseService;
 import edu.handong.csee.histudy.service.ReportService;
 import edu.handong.csee.histudy.service.TeamService;
@@ -33,27 +35,38 @@ public class TeamController {
 
     @Operation(summary = "그룹 스터디 보고서 생성")
     @PostMapping("/reports")
-    public ReportDto.ReportInfo createReport(@RequestBody ReportForm form,
-                                             @RequestAttribute Claims claims) {
-        return reportService.createReport(form, claims.getSubject());
+    public ReportDto.ReportInfo createReport(
+            @RequestBody ReportForm form,
+            @RequestAttribute Claims claims) {
+        if (Role.isAuthorized(claims, Role.MEMBER)) {
+            return reportService.createReport(form, claims.getSubject());
+        }
+        throw new ForbiddenException();
     }
 
     @Operation(summary = "그룹 보고서 목록 조회")
     @GetMapping("/reports")
-    public ReportDto getMyGroupReports(@RequestAttribute Claims claims) {
-        List<ReportDto.ReportInfo> reports = reportService.getReports(claims.getSubject());
-
-        return new ReportDto(reports);
+    public ReportDto getMyGroupReports(
+            @RequestAttribute Claims claims) {
+        if (Role.isAuthorized(claims, Role.MEMBER)) {
+            List<ReportDto.ReportInfo> reports = reportService.getReports(claims.getSubject());
+            return new ReportDto(reports);
+        }
+        throw new ForbiddenException();
     }
 
     @Operation(summary = "그룹 특정 보고서 조회")
     @GetMapping("/reports/{reportId}")
-    public ResponseEntity<ReportDto.ReportInfo> getReport(@PathVariable Long reportId) {
-        Optional<ReportDto.ReportInfo> reportsOr = reportService.getReport(reportId);
-
-        return reportsOr
-                .map(ResponseEntity::ok)
-                .orElseGet(() -> ResponseEntity.notFound().build());
+    public ResponseEntity<ReportDto.ReportInfo> getReport(
+            @PathVariable Long reportId,
+            @RequestAttribute Claims claims) {
+        if (Role.isAuthorized(claims, Role.MEMBER)) {
+            Optional<ReportDto.ReportInfo> reportsOr = reportService.getReport(reportId);
+            return reportsOr
+                    .map(ResponseEntity::ok)
+                    .orElseGet(() -> ResponseEntity.notFound().build());
+        }
+        throw new ForbiddenException();
     }
 
     @Operation(summary = "그룹 특정 보고서 수정")
@@ -61,32 +74,49 @@ public class TeamController {
     @PatchMapping("/reports/{reportId}")
     public ResponseEntity<String> updateReport(
             @PathVariable Long reportId,
-            @RequestBody ReportForm form) {
-        return (reportService.updateReport(reportId, form))
-                ? ResponseEntity.ok().build()
-                : ResponseEntity.notFound().build();
+            @RequestBody ReportForm form,
+            @RequestAttribute Claims claims) {
+        if (Role.isAuthorized(claims, Role.MEMBER)) {
+            return (reportService.updateReport(reportId, form))
+                    ? ResponseEntity.ok().build()
+                    : ResponseEntity.notFound().build();
+        }
+        throw new ForbiddenException();
     }
 
     @Operation(summary = "그룹 특정 보고서 삭제")
     @Parameter(name = "reportId", in = ParameterIn.PATH, example = "1")
     @DeleteMapping("/reports/{reportId}")
-    public ResponseEntity<String> deleteReport(@PathVariable Long reportId) {
-        return (reportService.deleteReport(reportId))
-                ? ResponseEntity.ok().build()
-                : ResponseEntity.notFound().build();
+    public ResponseEntity<String> deleteReport(
+            @PathVariable Long reportId,
+            @RequestAttribute Claims claims) {
+        if (Role.isAuthorized(claims, Role.MEMBER)) {
+            return (reportService.deleteReport(reportId))
+                    ? ResponseEntity.ok().build()
+                    : ResponseEntity.notFound().build();
+        }
+        throw new ForbiddenException();
     }
 
     @Operation(summary = "그룹 선택 강의 목록 조회")
     @GetMapping("/courses")
-    public ResponseEntity<CourseDto> getTeamCourses(@RequestAttribute Claims claims) {
-        return ResponseEntity.ok(
-                new CourseDto(
-                        courseService.getTeamCourses(claims.getSubject())));
+    public ResponseEntity<CourseDto> getTeamCourses(
+            @RequestAttribute Claims claims) {
+        if (Role.isAuthorized(claims, Role.MEMBER)) {
+            return ResponseEntity.ok(
+                    new CourseDto(
+                            courseService.getTeamCourses(claims.getSubject())));
+        }
+        throw new ForbiddenException();
     }
 
     @Operation(summary = "그룹 팀원 목록 조회")
     @GetMapping("/users")
-    public ResponseEntity<List<UserDto.UserMe>> getTeamUsers(@RequestAttribute Claims claims) {
-        return ResponseEntity.ok(teamService.getTeamUsers(claims.getSubject()));
+    public ResponseEntity<List<UserDto.UserMe>> getTeamUsers(
+            @RequestAttribute Claims claims) {
+        if (Role.isAuthorized(claims, Role.MEMBER)) {
+            return ResponseEntity.ok(teamService.getTeamUsers(claims.getSubject()));
+        }
+        throw new ForbiddenException();
     }
 }

--- a/src/main/java/edu/handong/csee/histudy/controller/TeamController.java
+++ b/src/main/java/edu/handong/csee/histudy/controller/TeamController.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.Optional;
 
 @Tag(name = "스터디 그룹 API")
-@SecurityRequirement(name = "General")
+@SecurityRequirement(name = "MEMBER")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/team")

--- a/src/main/java/edu/handong/csee/histudy/controller/UserController.java
+++ b/src/main/java/edu/handong/csee/histudy/controller/UserController.java
@@ -32,12 +32,13 @@ public class UserController {
     @PostMapping
     public ResponseEntity<UserDto.UserLogin> createUser(@RequestBody UserInfo userInfo) {
         if (userService.signUp(userInfo)) {
-            JwtPair tokens = jwtService.issueToken(userInfo.getEmail(), userInfo.getName());
+            JwtPair tokens = jwtService.issueToken(userInfo.getEmail(), userInfo.getName(), Role.USER);
 
             return ResponseEntity.ok(UserDto.UserLogin.builder()
                     .isRegistered(true)
                     .tokenType("Bearer ")
                     .tokens(tokens)
+                    .role(Role.USER.name())
                     .build());
         }
         return ResponseEntity.badRequest().build();
@@ -61,8 +62,9 @@ public class UserController {
 
     @Operation(summary = "내 정보 조회")
     @SecurityRequirements({
-            @SecurityRequirement(name = "General"),
-            @SecurityRequirement(name = "Admin")
+            @SecurityRequirement(name = "USER"),
+            @SecurityRequirement(name = "MEMBER"),
+            @SecurityRequirement(name = "ADMIN")
     })
     @GetMapping("/me")
     public ResponseEntity<UserDto.UserMe> getMyInfo(@RequestAttribute Claims claims) {
@@ -74,7 +76,7 @@ public class UserController {
     }
 
     @Operation(summary = "스터디 그룹 신청 정보 조회")
-    @SecurityRequirement(name = "General")
+    @SecurityRequirement(name = "USER")
     @GetMapping("/me/forms")
     public ResponseEntity<ApplyFormDto> getMyApplicationForm(@RequestAttribute Claims claims) {
         Optional<ApplyFormDto> userInfo = userService.getUserInfo(claims.getSubject());
@@ -85,7 +87,7 @@ public class UserController {
     }
 
     @Operation(summary = "전체 유저 스터디 신청 정보 조회")
-    @SecurityRequirement(name = "Admin")
+    @SecurityRequirement(name = "ADMIN")
     @GetMapping("/manageUsers")
     public List<UserDto.UserInfo> userList(@RequestAttribute Claims claims) {
         return userService.getUsers(claims.getSubject());

--- a/src/main/java/edu/handong/csee/histudy/domain/Role.java
+++ b/src/main/java/edu/handong/csee/histudy/domain/Role.java
@@ -1,5 +1,20 @@
 package edu.handong.csee.histudy.domain;
 
+import io.jsonwebtoken.Claims;
+
+import java.util.Arrays;
+
 public enum Role {
-    USER, MEMBER, ADMIN
+    ADMIN, MEMBER, USER;
+
+    private final static String ROLE = "rol";
+
+    public static boolean isAuthorized(Claims claims, Role... role) {
+        String rol = claims.get(ROLE, String.class);
+
+        return Arrays
+                .stream(role)
+                .anyMatch(r ->
+                        r.name().equals(rol));
+    }
 }

--- a/src/main/java/edu/handong/csee/histudy/domain/Role.java
+++ b/src/main/java/edu/handong/csee/histudy/domain/Role.java
@@ -1,5 +1,5 @@
 package edu.handong.csee.histudy.domain;
 
 public enum Role {
-    USER, ADMIN
+    USER, MEMBER, ADMIN
 }

--- a/src/main/java/edu/handong/csee/histudy/domain/User.java
+++ b/src/main/java/edu/handong/csee/histudy/domain/User.java
@@ -57,6 +57,7 @@ public class User {
     public void belongTo(Team team) {
         this.team = team;
         team.getUsers().add(this);
+        this.role = Role.MEMBER;
     }
 
     public void add(List<User> users) {
@@ -97,7 +98,7 @@ public class User {
         this.team = null;
     }
 
-    public void edit(UserDto.UserEdit dto,Team team) {
+    public void edit(UserDto.UserEdit dto, Team team) {
         this.sid = dto.getSid();
         this.name = dto.getName();
         this.team = team;

--- a/src/main/java/edu/handong/csee/histudy/dto/ExceptionResponse.java
+++ b/src/main/java/edu/handong/csee/histudy/dto/ExceptionResponse.java
@@ -1,0 +1,23 @@
+package edu.handong.csee.histudy.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@NoArgsConstructor
+public class ExceptionResponse {
+    private Integer code;
+    private String error;
+    private String message;
+    private String trace;
+
+    @Builder
+    public ExceptionResponse(HttpStatus status, String message, String trace) {
+        this.code = status.value();
+        this.error = status.getReasonPhrase();
+        this.message = message;
+        this.trace = trace;
+    }
+}

--- a/src/main/java/edu/handong/csee/histudy/dto/UserDto.java
+++ b/src/main/java/edu/handong/csee/histudy/dto/UserDto.java
@@ -49,6 +49,9 @@ public class UserDto {
 
         @Schema(description = "Token pairs", type = "object")
         private JwtPair tokens;
+
+        @Schema(description = "Role", example = "USER")
+        private String role;
     }
 
     @Builder
@@ -143,6 +146,7 @@ public class UserDto {
         }
 
     }
+
     @Builder
     @Getter
     @NoArgsConstructor

--- a/src/main/java/edu/handong/csee/histudy/exception/ForbiddenException.java
+++ b/src/main/java/edu/handong/csee/histudy/exception/ForbiddenException.java
@@ -1,0 +1,8 @@
+package edu.handong.csee.histudy.exception;
+
+public class ForbiddenException extends RuntimeException {
+
+    public ForbiddenException() {
+        super("권한이 없습니다.");
+    }
+}

--- a/src/main/java/edu/handong/csee/histudy/interceptor/AuthenticationInterceptor.java
+++ b/src/main/java/edu/handong/csee/histudy/interceptor/AuthenticationInterceptor.java
@@ -28,10 +28,10 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
         Optional<String> token = Optional.ofNullable(request.getHeader(HttpHeaders.AUTHORIZATION))
                 .filter(value -> value.startsWith(BEARER))
                 .map(value -> value.substring(BEARER.length()));
-        Optional<Claims> claims = jwtService.validate(token);
+        Optional<Claims> claimsOr = jwtService.validate(token);
 
-        if (claims.isPresent()) {
-            request.setAttribute("claims", claims.get());
+        if (claimsOr.isPresent()) {
+            request.setAttribute("claims", claimsOr.get());
             return true;
         }
         response.sendError(HttpStatus.UNAUTHORIZED.value());

--- a/src/main/java/edu/handong/csee/histudy/service/UserService.java
+++ b/src/main/java/edu/handong/csee/histudy/service/UserService.java
@@ -119,10 +119,11 @@ public class UserService {
 
         return new UserDto.UserInfo(user);
     }
+
     public UserDto.UserInfo editUser(UserDto.UserEdit dto) {
         User user = userRepository.findById(dto.getId()).orElseThrow();
         Team team = teamRepository.findByTag(dto.getTeam()).orElseThrow();
-        user.edit(dto,team);
+        user.edit(dto, team);
         return new UserDto.UserInfo(user);
     }
 }

--- a/src/test/java/edu/handong/csee/histudy/admin/AdminControllerTests.java
+++ b/src/test/java/edu/handong/csee/histudy/admin/AdminControllerTests.java
@@ -9,6 +9,8 @@ import edu.handong.csee.histudy.dto.UserDto;
 import edu.handong.csee.histudy.interceptor.AuthenticationInterceptor;
 import edu.handong.csee.histudy.repository.CourseRepository;
 import edu.handong.csee.histudy.repository.UserRepository;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -90,6 +92,9 @@ public class AdminControllerTests {
                 .name("courseName")
                 .build());
 
+        Claims claims = Jwts.claims();
+        claims.put("rol", Role.ADMIN.name());
+
         user.add(List.of(friend, friend2));
         friend.add(List.of(user));
         user.select(List.of(course, course, course));
@@ -97,7 +102,8 @@ public class AdminControllerTests {
         // when
         MvcResult mvcResult = mvc
                 .perform(delete("/api/admin/form")
-                        .queryParam("sid", user.getSid()))
+                        .queryParam("sid", user.getSid())
+                        .requestAttr("claims", claims))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andReturn();

--- a/src/test/java/edu/handong/csee/histudy/app/AppControllerTests.java
+++ b/src/test/java/edu/handong/csee/histudy/app/AppControllerTests.java
@@ -2,8 +2,10 @@ package edu.handong.csee.histudy.app;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.handong.csee.histudy.controller.ApplyFormController;
+import edu.handong.csee.histudy.controller.ExceptionController;
 import edu.handong.csee.histudy.controller.form.ApplyForm;
 import edu.handong.csee.histudy.domain.Course;
+import edu.handong.csee.histudy.domain.Role;
 import edu.handong.csee.histudy.domain.User;
 import edu.handong.csee.histudy.dto.ApplyFormDto;
 import edu.handong.csee.histudy.interceptor.AuthenticationInterceptor;
@@ -60,6 +62,7 @@ public class AppControllerTests {
         mvc = MockMvcBuilders
                 .standaloneSetup(applyFormController)
                 .addInterceptors(interceptor)
+                .setControllerAdvice(ExceptionController.class)
                 .build();
         when(interceptor.preHandle(any(), any(), any())).thenReturn(true);
     }
@@ -68,9 +71,10 @@ public class AppControllerTests {
     @Test
     void AppControllerTests_26() throws Exception {
         // given
-        userRepository.save(
+        User saved = userRepository.save(
                 User.builder()
                         .email("test@example.com")
+                        .role(Role.USER)
                         .build());
 
         courseRepository.save(
@@ -89,7 +93,8 @@ public class AppControllerTests {
         String form = mapper.writeValueAsString(applyForm);
 
         Claims claims = Jwts.claims();
-        claims.put("sub", "test@example.com");
+        claims.put("sub", saved.getEmail());
+        claims.put("rol", saved.getRole().name());
 
         // when
         mvc.perform(post("/api/forms")
@@ -123,6 +128,7 @@ public class AppControllerTests {
 
         Claims claims = Jwts.claims();
         claims.put("sub", "subB");
+        claims.put("rol", Role.USER.name());
 
         // when
         mvc.perform(post("/api/forms")
@@ -140,6 +146,8 @@ public class AppControllerTests {
         // given
         userRepository.save(
                 User.builder()
+                        .sub("subA")
+                        .role(Role.USER)
                         .build());
 
         ApplyForm applyForm = ApplyForm.builder()
@@ -150,6 +158,7 @@ public class AppControllerTests {
 
         Claims claims = Jwts.claims();
         claims.put("sub", "subA");
+        claims.put("rol", Role.USER.name());
 
         // when
         mvc
@@ -166,10 +175,11 @@ public class AppControllerTests {
     @Test
     void AppControllerTests_166() throws Exception {
         // given
-        userRepository.save(
+        User saved = userRepository.save(
                 User.builder()
                         .sid("sidA")
                         .email("test@example.com")
+                        .role(Role.USER)
                         .build());
         userRepository.save(
                 User.builder()
@@ -197,7 +207,8 @@ public class AppControllerTests {
         String form = mapper.writeValueAsString(applyForm);
 
         Claims claims = Jwts.claims();
-        claims.put("sub", "test@example.com");
+        claims.put("sub", saved.getEmail());
+        claims.put("rol", saved.getRole().name());
 
         // when
         mvc.perform(post("/api/forms")

--- a/src/test/java/edu/handong/csee/histudy/auth/AuthControllerTests.java
+++ b/src/test/java/edu/handong/csee/histudy/auth/AuthControllerTests.java
@@ -2,6 +2,7 @@ package edu.handong.csee.histudy.auth;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.handong.csee.histudy.controller.form.TokenForm;
+import edu.handong.csee.histudy.domain.Role;
 import edu.handong.csee.histudy.domain.User;
 import edu.handong.csee.histudy.dto.UserDto;
 import edu.handong.csee.histudy.jwt.GrantType;
@@ -55,6 +56,7 @@ public class AuthControllerTests {
                 .email("test@example.com")
                 .name("username")
                 .sub("1234")
+                .role(Role.USER)
                 .build();
         userRepository.save(user);
 

--- a/src/test/java/edu/handong/csee/histudy/course/CourseControllerTests.java
+++ b/src/test/java/edu/handong/csee/histudy/course/CourseControllerTests.java
@@ -4,9 +4,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.handong.csee.histudy.controller.ApplyFormController;
 import edu.handong.csee.histudy.controller.CourseController;
 import edu.handong.csee.histudy.domain.Course;
+import edu.handong.csee.histudy.domain.Role;
 import edu.handong.csee.histudy.dto.CourseDto;
 import edu.handong.csee.histudy.interceptor.AuthenticationInterceptor;
 import edu.handong.csee.histudy.repository.CourseRepository;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -74,10 +77,14 @@ public class CourseControllerTests {
                 .build();
         courseRepository.save(c);
 
+        Claims claims = Jwts.claims();
+        claims.put("rol", Role.USER.name());
+
         // when
         MvcResult mvcResult = mvc
                 .perform(get("/api/courses")
-                        .queryParam("search", "soft"))
+                        .queryParam("search", "soft")
+                        .requestAttr("claims", claims))
                 .andExpect(status().isOk())
                 .andDo(print())
                 .andReturn();
@@ -93,8 +100,12 @@ public class CourseControllerTests {
     @DisplayName("해당하는 목록이 없는 경우 빈 배열을 응답한다")
     @Test
     void CourseControllerTests_88() throws Exception {
+        Claims claims = Jwts.claims();
+        claims.put("rol", Role.USER.name());
+
         MvcResult mvcResult = mvc
-                .perform(get("/api/courses"))
+                .perform(get("/api/courses")
+                        .requestAttr("claims", claims))
                 .andExpect(status().isOk())
                 .andDo(print())
                 .andReturn();
@@ -127,9 +138,13 @@ public class CourseControllerTests {
         courseRepository.save(c1);
         courseRepository.save(c2);
 
+        Claims claims = Jwts.claims();
+        claims.put("rol", Role.USER.name());
+
         // when
         MvcResult mvcResult = mvc
-                .perform(get("/api/courses"))
+                .perform(get("/api/courses")
+                        .requestAttr("claims", claims))
                 .andExpect(status().isOk())
                 .andDo(print())
                 .andReturn();

--- a/src/test/java/edu/handong/csee/histudy/report/ReportControllerTests.java
+++ b/src/test/java/edu/handong/csee/histudy/report/ReportControllerTests.java
@@ -3,10 +3,7 @@ package edu.handong.csee.histudy.report;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.handong.csee.histudy.controller.TeamController;
 import edu.handong.csee.histudy.controller.form.ReportForm;
-import edu.handong.csee.histudy.domain.Course;
-import edu.handong.csee.histudy.domain.Report;
-import edu.handong.csee.histudy.domain.Team;
-import edu.handong.csee.histudy.domain.User;
+import edu.handong.csee.histudy.domain.*;
 import edu.handong.csee.histudy.dto.ReportDto;
 import edu.handong.csee.histudy.interceptor.AuthenticationInterceptor;
 import edu.handong.csee.histudy.repository.CourseRepository;
@@ -80,6 +77,7 @@ public class ReportControllerTests {
                 .sid("21811111")
                 .name("username")
                 .email("user@test.com")
+                .role(Role.MEMBER)
                 .build());
         user.belongTo(new Team(1));
 
@@ -97,8 +95,9 @@ public class ReportControllerTests {
                 .build();
         reportRepository.save(report);
 
-        Claims claims = Jwts.claims(
-                Collections.singletonMap(Claims.SUBJECT, user.getEmail()));
+        Claims claims = Jwts.claims();
+        claims.put("sub", user.getEmail());
+        claims.put("rol", user.getRole().name());
 
         // when
         MvcResult mvcResult = mvc
@@ -124,6 +123,7 @@ public class ReportControllerTests {
                 .sid("21811111")
                 .name("username")
                 .email("user@test.com")
+                .role(Role.MEMBER)
                 .build());
         user.belongTo(new Team(1));
 
@@ -141,8 +141,9 @@ public class ReportControllerTests {
                 .build();
         reportRepository.save(report);
 
-        Claims claims = Jwts.claims(
-                Collections.singletonMap(Claims.SUBJECT, user.getEmail()));
+        Claims claims = Jwts.claims();
+        claims.put("sub", user.getEmail());
+        claims.put("rol", user.getRole().name());
 
         // when
         MvcResult mvcResult = mvc
@@ -205,6 +206,7 @@ public class ReportControllerTests {
                 .sid("21811111")
                 .name("username")
                 .email("user@test.com")
+                .role(Role.MEMBER)
                 .build());
         user.belongTo(new Team(1));
 
@@ -226,10 +228,15 @@ public class ReportControllerTests {
                 .title("modified title")
                 .build());
 
+        Claims claims = Jwts.claims();
+        claims.put("sub", user.getEmail());
+        claims.put("rol", user.getRole().name());
+
         // when
         mvc
                 .perform(patch("/api/team/reports/{reportId}", report.getId())
                         .contentType(MediaType.APPLICATION_JSON)
+                        .requestAttr("claims", claims)
                         .content(form))
                 .andDo(print())
                 .andExpect(status().isOk())
@@ -244,6 +251,7 @@ public class ReportControllerTests {
                 .sid("21811111")
                 .name("username")
                 .email("user@test.com")
+                .role(Role.USER)
                 .build());
         user.belongTo(new Team(1));
 
@@ -261,13 +269,14 @@ public class ReportControllerTests {
                 .build();
         reportRepository.save(report);
 
-        String form = mapper.writeValueAsString(ReportForm.builder()
-                .title("modified title")
-                .build());
+        Claims claims = Jwts.claims();
+        claims.put("sub", user.getEmail());
+        claims.put("rol", user.getRole().name());
 
         // when
         mvc
-                .perform(delete("/api/team/reports/{reportId}", report.getId()))
+                .perform(delete("/api/team/reports/{reportId}", report.getId())
+                        .requestAttr("claims", claims))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andReturn();
@@ -281,6 +290,7 @@ public class ReportControllerTests {
                 .sid("21811111")
                 .name("username")
                 .email("user@test.com")
+                .role(Role.MEMBER)
                 .build());
         user.belongTo(new Team(1));
 
@@ -298,9 +308,14 @@ public class ReportControllerTests {
                 .build();
         reportRepository.save(report);
 
+        Claims claims = Jwts.claims();
+        claims.put("sub", user.getEmail());
+        claims.put("rol", user.getRole().name());
+
         // when
         mvc
-                .perform(delete("/api/team/reports/{reportId}", 333))
+                .perform(delete("/api/team/reports/{reportId}", 333)
+                        .requestAttr("claims", claims))
                 .andDo(print())
                 .andExpect(status().isNotFound())
                 .andReturn();

--- a/src/test/java/edu/handong/csee/histudy/team/TeamControllerTests.java
+++ b/src/test/java/edu/handong/csee/histudy/team/TeamControllerTests.java
@@ -3,6 +3,7 @@ package edu.handong.csee.histudy.team;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.handong.csee.histudy.controller.TeamController;
 import edu.handong.csee.histudy.domain.Course;
+import edu.handong.csee.histudy.domain.Role;
 import edu.handong.csee.histudy.domain.Team;
 import edu.handong.csee.histudy.domain.User;
 import edu.handong.csee.histudy.dto.CourseDto;
@@ -75,10 +76,12 @@ public class TeamControllerTests {
         User userA = User.builder()
                 .sid("201511111")
                 .email("userA@test.com")
+                .role(Role.USER)
                 .build();
         User userB = User.builder()
                 .sid("201611111")
                 .email("userB@test.com")
+                .role(Role.USER)
                 .build();
         Course courseA = Course.builder()
                 .name("courseA")
@@ -92,9 +95,6 @@ public class TeamControllerTests {
         Course savedCourse1 = courseRepository.save(courseA);
         Course savedCourse2 = courseRepository.save(courseB);
 
-        Claims claimsA = Jwts.claims();
-        claimsA.put("sub", userA.getEmail());
-
         Claims claimsB = Jwts.claims();
         claimsB.put("sub", userB.getEmail());
 
@@ -105,6 +105,11 @@ public class TeamControllerTests {
 
         save2.getTeam()
                 .select(List.of(savedCourse1, savedCourse2));
+
+        Claims claimsA = Jwts.claims();
+        claimsA.put("sub", userA.getEmail());
+        claimsA.put("rol", userA.getRole().name());
+
         // when
         MvcResult mvcResult = mvc
                 .perform(get("/api/team/courses")

--- a/src/test/java/edu/handong/csee/histudy/user/UserControllerMockTests.java
+++ b/src/test/java/edu/handong/csee/histudy/user/UserControllerMockTests.java
@@ -141,7 +141,7 @@ public class UserControllerMockTests {
 
         // when
         when(userService.signUp(any())).thenReturn(true);
-        when(jwtService.issueToken(any(), any())).thenReturn(new JwtPair(tokens));
+        when(jwtService.issueToken(any(), any(), any())).thenReturn(new JwtPair(tokens));
 
         MvcResult mvcResult = mockMvc
                 .perform(post("/api/users")

--- a/src/test/java/edu/handong/csee/histudy/user/UserControllerTests.java
+++ b/src/test/java/edu/handong/csee/histudy/user/UserControllerTests.java
@@ -28,13 +28,11 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -80,6 +78,7 @@ public class UserControllerTests {
                 .sid("123")
                 .name("test")
                 .email("test@example.com")
+                .role(Role.USER)
                 .build());
         User friend = userRepository.save(User.builder()
                 .sid("234")
@@ -97,8 +96,9 @@ public class UserControllerTests {
                         .build(),
                 saved.getEmail());
 
-        Claims claims = Jwts.claims(
-                Collections.singletonMap("sub", saved.getEmail()));
+        Claims claims = Jwts.claims();
+        claims.put("sub", saved.getEmail());
+        claims.put("rol", saved.getRole().name());
 
         // when
         MvcResult mvcResult = mvc
@@ -125,6 +125,7 @@ public class UserControllerTests {
                 .sid("123")
                 .name("test")
                 .email("test@example.com")
+                .role(Role.USER)
                 .build());
         User friend = userRepository.save(User.builder()
                 .sid("234")
@@ -157,8 +158,9 @@ public class UserControllerTests {
                         .build(),
                 saved.getEmail());
 
-        Claims claims = Jwts.claims(
-                Collections.singletonMap("sub", saved.getEmail()));
+        Claims claims = Jwts.claims();
+        claims.put("sub", saved.getEmail());
+        claims.put("rol", saved.getRole().name());
 
         // when
         MvcResult mvcResult = mvc
@@ -187,10 +189,12 @@ public class UserControllerTests {
                 .sid("123")
                 .name("test")
                 .email("test@example.com")
+                .role(Role.USER)
                 .build());
 
-        Claims claims = Jwts.claims(
-                Collections.singletonMap("sub", saved.getEmail()));
+        Claims claims = Jwts.claims();
+        claims.put("sub", saved.getEmail());
+        claims.put("rol", saved.getRole().name());
 
         // when
         MvcResult mvcResult = mvc


### PR DESCRIPTION
- 토큰에 반드시 권한(`rol`)을 명시하도록 하고 권한에 따라 접근할 수 있는 엔드포인트 제한을 두었음.
- 로그인/회원가입시 유저의 권한 정보를 응답하여 접근 가능한 메뉴를 선택적으로 보이게 할 수 있음.