### PR TITLE
Feat: 과목 기반 매칭 단계 추가 (#112)

### DIFF
--- a/src/main/java/edu/handong/csee/histudy/domain/User.java
+++ b/src/main/java/edu/handong/csee/histudy/domain/User.java
@@ -125,4 +125,8 @@ public class User extends BaseTime {
         this.addUser(Collections.emptyList());
         this.selectCourse(Collections.emptyList());
     }
+
+    public boolean isNotInStudyGroup() {
+        return this.studyGroup == null;
+    }
 }

--- a/src/main/java/edu/handong/csee/histudy/dto/UserDto.java
+++ b/src/main/java/edu/handong/csee/histudy/dto/UserDto.java
@@ -2,10 +2,12 @@ package edu.handong.csee.histudy.dto;
 
 import edu.handong.csee.histudy.domain.Friendship;
 import edu.handong.csee.histudy.domain.User;
+import edu.handong.csee.histudy.domain.UserCourse;
 import edu.handong.csee.histudy.jwt.JwtPair;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
+import java.util.Comparator;
 import java.util.List;
 
 @AllArgsConstructor
@@ -92,6 +94,7 @@ public class UserDto {
                     .map(UserBasic::new)
                     .toList();
             this.courses = user.getCourseSelections().stream()
+                    .sorted(Comparator.comparing(UserCourse::getPriority))
                     .map(c -> new CourseIdNameDto(c.getCourse()))
                     .toList();
             this.totalMinutes = user.getReportParticipation().stream()

--- a/src/test/java/edu/handong/csee/histudy/algo/MatchingAlgorithmTests.java
+++ b/src/test/java/edu/handong/csee/histudy/algo/MatchingAlgorithmTests.java
@@ -221,22 +221,24 @@ public class MatchingAlgorithmTests {
         teams.matchTeam();
         List<StudyGroup> all = studyGroupRepository.findAll();
 
-        all.forEach(team -> {
-            System.out.println("========================================");
-            System.out.println("Team " + team.getTag() + ":");
-            System.out.println("Members:");
-            team.getMembers().forEach(user -> {
-                System.out.println(user.getName() +
-                        "(" + user.getCourseSelections().get(0).getCourse().getName() + ", " +
-                        user.getCourseSelections().get(1).getCourse().getName() + ", " +
-                        user.getCourseSelections().get(2).getCourse().getName() + ")");
-            });
-            System.out.println("Friends:");
-            team.getMembers().forEach(u -> u.getSentRequests().stream().filter(Friendship::isAccepted).forEach(friendship ->
-                    System.out.println(friendship.getSent().getName() + " -> " + friendship.getReceived().getName())));
-            System.out.println("Common courses:");
-            team.getGroupCourses().forEach(enroll -> System.out.println(enroll.getCourse().getName()));
-            System.out.println("========================================");
-        });
+        all.stream().sorted(Comparator.comparingInt(StudyGroup::getTag))
+                .forEach(team -> {
+                    System.out.println("========================================");
+                    System.out.println("Team " + team.getTag() + ":");
+                    System.out.println("Members:");
+                    team.getMembers().forEach(user -> {
+                        user.getCourseSelections().sort(Comparator.comparingInt(UserCourse::getPriority));
+                        System.out.println(user.getName() +
+                                "(" + user.getCourseSelections().get(0).getCourse().getName() + ", " +
+                                user.getCourseSelections().get(1).getCourse().getName() + ", " +
+                                user.getCourseSelections().get(2).getCourse().getName() + ")");
+                    });
+                    System.out.println("Friends:");
+                    team.getMembers().forEach(u -> u.getSentRequests().stream().filter(Friendship::isAccepted).forEach(friendship ->
+                            System.out.println(friendship.getSent().getName() + " -> " + friendship.getReceived().getName())));
+                    System.out.println("Common courses:");
+                    team.getGroupCourses().forEach(enroll -> System.out.println(enroll.getCourse().getName()));
+                    System.out.println("========================================");
+                });
     }
 }

--- a/src/test/java/edu/handong/csee/histudy/group/ReportGroupCourseServiceTest.java
+++ b/src/test/java/edu/handong/csee/histudy/group/ReportGroupCourseServiceTest.java
@@ -106,11 +106,12 @@ public class ReportGroupCourseServiceTest {
                 .filter(Optional::isPresent)
                 .map(Optional::get)
                 .toList();
-        List<UserCourse> preferredCours = courses.stream().map(c -> userCourseRepository.save(UserCourse.builder()
+        List<UserCourse> preferredCourse = courses.stream().map(c -> userCourseRepository.save(UserCourse.builder()
                 .user(savedA)
                 .course(c)
+                .priority(0)
                 .build())).toList();
-        savedA.getCourseSelections().addAll(preferredCours);
+        savedA.getCourseSelections().addAll(preferredCourse);
         List<Long> courseIdxList2 = List.of(1L, 2L, 3L);
         List<Course> courses2 = courseIdxList2.stream()
                 .map(courseRepository::findById)
@@ -120,6 +121,7 @@ public class ReportGroupCourseServiceTest {
         List<UserCourse> choices2 = courses2.stream().map(c -> userCourseRepository.save(UserCourse.builder()
                 .user(savedB)
                 .course(c)
+                .priority(0)
                 .build())).toList();
         savedB.getCourseSelections().addAll(choices2);
         StudyGroup studyGroup = studyGroupRepository.save(new StudyGroup(111, List.of(savedA, savedB)));

--- a/src/test/java/edu/handong/csee/histudy/user/UserServiceTests.java
+++ b/src/test/java/edu/handong/csee/histudy/user/UserServiceTests.java
@@ -174,11 +174,12 @@ public class UserServiceTests {
                 .filter(Optional::isPresent)
                 .map(Optional::get)
                 .toList();
-        List<UserCourse> preferredCours = courses.stream().map(c -> userCourseRepository.save(UserCourse.builder()
+        List<UserCourse> preferredCourse = courses.stream().map(c -> userCourseRepository.save(UserCourse.builder()
                 .user(savedA)
                 .course(c)
+                .priority(0)
                 .build())).toList();
-        savedA.getCourseSelections().addAll(preferredCours);
+        savedA.getCourseSelections().addAll(preferredCourse);
         List<Long> courseIdxList2 = courseRepository.findAll().stream().map(Course::getId).toList();
         List<Course> courses2 = courseIdxList2.stream()
                 .map(courseRepository::findById)
@@ -188,6 +189,7 @@ public class UserServiceTests {
         List<UserCourse> choices2 = courses2.stream().map(c -> userCourseRepository.save(UserCourse.builder()
                 .user(savedB)
                 .course(c)
+                .priority(0)
                 .build())).toList();
         savedB.getCourseSelections().addAll(choices2);
         StudyGroup studyGroup = studyGroupRepository.save(new StudyGroup(111, List.of(savedA, savedB)));


### PR DESCRIPTION
1. 친구 매칭: 같이 공부하기로 한 친구를 선택한 경우
2. 우선순위 기반 매칭: 1 -> 2 -> 3순위 과목에 대한 매칭 진행 (1순위는 1순위끼리, 2순위는 2순위끼리, 3순위는 3순위끼리)
3. 과목 기반 매칭: 남은 과목 중 우선순위가 높은 학생부터 매칭 ( N개의 남은 과목 각각에 대해 우선순위가 높은 학생부터 매칭)