### PR TITLE
Fix: 그룹 미배정 유저의 정보를 수정할 수 없었던 버그 수정 (#115)

### DIFF
--- a/src/main/java/edu/handong/csee/histudy/controller/AdminController.java
+++ b/src/main/java/edu/handong/csee/histudy/controller/AdminController.java
@@ -103,10 +103,10 @@ public class AdminController {
     @Operation(summary = "유저 정보 수정")
     @PostMapping("/edit-user")
     public UserDto.UserInfo editUser(
-            @RequestBody UserDto.UserEdit dto,
+            @RequestBody UserDto.UserEdit form,
             @RequestAttribute Claims claims) {
         if (Role.isAuthorized(claims, Role.ADMIN)) {
-            return userService.editUser(dto);
+            return userService.editUser(form);
         }
         throw new ForbiddenException();
     }

--- a/src/main/java/edu/handong/csee/histudy/domain/StudyGroup.java
+++ b/src/main/java/edu/handong/csee/histudy/domain/StudyGroup.java
@@ -71,7 +71,7 @@ public class StudyGroup extends BaseTime {
                 : commonCourses;
     }
 
-    protected StudyGroup join(List<User> users) {
+    public StudyGroup join(List<User> users) {
         users.forEach(u -> u.belongTo(this));
         getCommonCourses()
                 .forEach(course -> {

--- a/src/main/java/edu/handong/csee/histudy/domain/User.java
+++ b/src/main/java/edu/handong/csee/histudy/domain/User.java
@@ -13,6 +13,8 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static java.util.Objects.*;
+
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -121,8 +123,8 @@ public class User extends BaseTime {
     }
 
     public void edit(UserDto.UserEdit dto) {
-        this.sid = dto.getSid();
-        this.name = dto.getName();
+        this.sid = requireNonNullElse(dto.getSid(), this.sid);
+        this.name = requireNonNullElse(dto.getName(), this.name);
     }
 
     public void resetPreferences() {

--- a/src/main/java/edu/handong/csee/histudy/domain/User.java
+++ b/src/main/java/edu/handong/csee/histudy/domain/User.java
@@ -61,6 +61,11 @@ public class User extends BaseTime {
     }
 
     public void belongTo(StudyGroup studyGroup) {
+        if (isInSameGroup(studyGroup)) {
+            return;
+        } else if (isAlreadyInOtherGroup(studyGroup)) {
+            leaveGroup();
+        }
         this.studyGroup = studyGroup;
         studyGroup.getMembers().add(this);
         this.role = Role.MEMBER;
@@ -115,10 +120,9 @@ public class User extends BaseTime {
         this.studyGroup = null;
     }
 
-    public void edit(UserDto.UserEdit dto, StudyGroup studyGroup) {
+    public void edit(UserDto.UserEdit dto) {
         this.sid = dto.getSid();
         this.name = dto.getName();
-        studyGroup.join(List.of(this));
     }
 
     public void resetPreferences() {
@@ -126,7 +130,21 @@ public class User extends BaseTime {
         this.selectCourse(Collections.emptyList());
     }
 
-    public boolean isNotInStudyGroup() {
+    public boolean isNotInAnyGroup() {
         return this.studyGroup == null;
+    }
+
+    private void leaveGroup() {
+        this.studyGroup.getMembers().remove(this);
+        this.studyGroup = null;
+        this.role = Role.USER;
+    }
+
+    private boolean isAlreadyInOtherGroup(StudyGroup studyGroup) {
+        return this.studyGroup != null && !this.studyGroup.equals(studyGroup);
+    }
+
+    public boolean isInSameGroup(StudyGroup studyGroup) {
+        return this.studyGroup != null && this.studyGroup.equals(studyGroup);
     }
 }

--- a/src/main/java/edu/handong/csee/histudy/dto/UserDto.java
+++ b/src/main/java/edu/handong/csee/histudy/dto/UserDto.java
@@ -154,9 +154,17 @@ public class UserDto {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class UserEdit {
+
+        @Schema(description = "User ID")
         private Long id;
-        private int team;
+
+        @Schema(description = "Group tag", example = "112")
+        private Integer team;
+
+        @Schema(description = "User name", example = "John Doe")
         private String name;
+
+        @Schema(description = "User student ID", example = "21800012")
         private String sid;
     }
 }

--- a/src/main/java/edu/handong/csee/histudy/exception/StudyGroupNotFoundException.java
+++ b/src/main/java/edu/handong/csee/histudy/exception/StudyGroupNotFoundException.java
@@ -1,0 +1,7 @@
+package edu.handong.csee.histudy.exception;
+
+public class StudyGroupNotFoundException extends RuntimeException {
+    public StudyGroupNotFoundException() {
+        super("해당하는 스터디 그룹을 찾을 수 없습니다.");
+    }
+}

--- a/src/main/java/edu/handong/csee/histudy/service/TeamService.java
+++ b/src/main/java/edu/handong/csee/histudy/service/TeamService.java
@@ -96,18 +96,18 @@ public class TeamService {
                 .toList());
 
         // Third matching
-        List<StudyGroup> matchedCourseSecond = matchCourseSecond(users, tag);
+//        List<StudyGroup> matchedCourseSecond = matchCourseSecond(users, tag);
 
         // Results
         List<StudyGroup> matchedStudyGroups = new ArrayList<>(teamsWithFriends);
         matchedStudyGroups.addAll(teamsWithoutFriends);
-        matchedStudyGroups.addAll(matchedCourseSecond);
-
-        // Remove users who have already been matched
-        users.removeAll(matchedCourseSecond.stream()
-                .map(StudyGroup::getMembers)
-                .flatMap(Collection::stream)
-                .toList());
+//        matchedStudyGroups.addAll(matchedCourseSecond);
+//
+//        // Remove users who have already been matched
+//        users.removeAll(matchedCourseSecond.stream()
+//                .map(StudyGroup::getMembers)
+//                .flatMap(Collection::stream)
+//                .toList());
 
         return new TeamDto.MatchResults(matchedStudyGroups, userService.getInfoFromUser(users));
     }
@@ -144,7 +144,7 @@ public class TeamService {
             Map<Course, List<User>> courseToUserMap = userCourses.stream()
                     .filter(uc ->
                             uc.getPriority().equals(priority)
-                                    && uc.getUser().isNotInStudyGroup())
+                                    && uc.getUser().isNotInAnyGroup())
                     .collect(Collectors.groupingBy(
                             UserCourse::getCourse,
                             Collectors.mapping(UserCourse::getUser, Collectors.toList())));
@@ -191,7 +191,7 @@ public class TeamService {
         // Make teams with 3 ~ 5 elements
         courseToUserByPriority.forEach((course, queue) -> {
             List<User> group = queue.stream()
-                    .filter(User::isNotInStudyGroup)
+                    .filter(User::isNotInAnyGroup)
                     .sorted(queue.comparator())
                     .collect(Collectors.toList());
 

--- a/src/main/java/edu/handong/csee/histudy/service/UserService.java
+++ b/src/main/java/edu/handong/csee/histudy/service/UserService.java
@@ -8,10 +8,7 @@ import edu.handong.csee.histudy.domain.StudyGroup;
 import edu.handong.csee.histudy.domain.User;
 import edu.handong.csee.histudy.dto.ApplyFormDto;
 import edu.handong.csee.histudy.dto.UserDto;
-import edu.handong.csee.histudy.exception.MissingEmailException;
-import edu.handong.csee.histudy.exception.MissingSubException;
-import edu.handong.csee.histudy.exception.UserAlreadyExistsException;
-import edu.handong.csee.histudy.exception.UserNotFoundException;
+import edu.handong.csee.histudy.exception.*;
 import edu.handong.csee.histudy.repository.CourseRepository;
 import edu.handong.csee.histudy.repository.StudyGroupRepository;
 import edu.handong.csee.histudy.repository.UserCourseRepository;
@@ -132,10 +129,19 @@ public class UserService {
         return new UserDto.UserInfo(user);
     }
 
-    public UserDto.UserInfo editUser(UserDto.UserEdit dto) {
-        User user = userRepository.findById(dto.getId()).orElseThrow();
-        StudyGroup studyGroup = studyGroupRepository.findByTag(dto.getTeam()).orElseThrow();
-        user.edit(dto, studyGroup);
+    public UserDto.UserInfo editUser(UserDto.UserEdit form) {
+        User user = userRepository.findById(form.getId())
+                .orElseThrow(UserNotFoundException::new);
+
+        Optional.ofNullable(form.getTeam())
+                .ifPresent(
+                        tag ->
+                                studyGroupRepository
+                                        .findByTag(tag)
+                                        .orElseThrow(StudyGroupNotFoundException::new)
+                                        .join(List.of(user))
+                );
+        user.edit(form);
         return new UserDto.UserInfo(user);
     }
 }

--- a/src/test/java/edu/handong/csee/histudy/user/UserServiceTests.java
+++ b/src/test/java/edu/handong/csee/histudy/user/UserServiceTests.java
@@ -272,16 +272,20 @@ public class UserServiceTests {
                 .email("a@a.com")
                 .role(Role.USER)
                 .build();
+
         User saved = userRepository.save(user);
         StudyGroup studyGroup = studyGroupRepository.save(new StudyGroup(111, List.of(saved)));
         StudyGroup newStudyGroup = studyGroupRepository.save(new StudyGroup(222, List.of()));
+
         UserDto.UserEdit dto = UserDto.UserEdit.builder()
                 .id(saved.getId())
                 .sid("12345678")
                 .name("조용히해라")
                 .team(222)
                 .build();
+
         UserDto.UserInfo edited = userService.editUser(dto);
+
         assertThat(edited.getName()).isEqualTo("조용히해라");
         assertThat(edited.getSid()).isEqualTo("12345678");
         assertThat(edited.getGroup()).isEqualTo(newStudyGroup.getTag());


### PR DESCRIPTION
- 그룹 배정된 유저에 대해 그룹을 떠나게 하는 건 고려 안함 (옮기는 건 가능)
- `null` 로 값을 보내면 그룹 변화는 없는 것으로 간주하고 그 외 정보만 수정 (단, 나머지 필드의 null 값은 허용하지 않음)