### PR TITLE
Feat: 그룹 배정된 학생을 미배정으로 변경 (#122)

### DIFF
--- a/src/main/java/edu/handong/csee/histudy/controller/AdminController.java
+++ b/src/main/java/edu/handong/csee/histudy/controller/AdminController.java
@@ -62,6 +62,14 @@ public class AdminController {
         throw new ForbiddenException();
     }
 
+    /**
+     * 스터디그룹 신청한 유저 목록 조회
+     *
+     * <p>스터디 그룹 배정을 신청했으나 아직 배정되지 않은 유저 목록을 표시한다</p>
+     *
+     * @param claims 토큰 페이로드
+     * @return 스터디그룹 신청한 유저 목록
+     */
     @Operation(summary = "신청한 유저 목록 조회")
     @GetMapping("/allUsers")
     public ResponseEntity<List<UserDto.UserInfo>> getAppliedUsers(@RequestAttribute Claims claims) {
@@ -80,6 +88,15 @@ public class AdminController {
         throw new ForbiddenException();
     }
 
+    /**
+     * 그룹 미배정 학생 목록 조회
+     *
+     * <p>스터디그룹 신청 여부와 관계 없이
+     * 가입된 유저 중에서 그룹이 배정되지 않은 유저 목록을 표시한다</p>
+     *
+     * @param claims 토큰 페이로드
+     * @return 그룹 미배정 학생 목록
+     */
     @Operation(summary = "매칭되지 않은 유저 목록 조회")
     @GetMapping("/unmatched-users")
     public ResponseEntity<List<UserDto.UserInfo>> getUnmatchedUsers(@RequestAttribute Claims claims) {

--- a/src/main/java/edu/handong/csee/histudy/domain/StudyGroup.java
+++ b/src/main/java/edu/handong/csee/histudy/domain/StudyGroup.java
@@ -29,7 +29,7 @@ public class StudyGroup extends BaseTime {
     @OneToMany(mappedBy = "studyGroup")
     private List<User> members = new ArrayList<>();
 
-    @OneToMany(mappedBy = "studyGroup", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "studyGroup", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<GroupCourse> groupCourses = new ArrayList<>();
 
     public StudyGroup(Integer tag, List<User> members) {
@@ -73,12 +73,7 @@ public class StudyGroup extends BaseTime {
 
     public StudyGroup join(List<User> users) {
         users.forEach(u -> u.belongTo(this));
-        getCommonCourses()
-                .forEach(course -> {
-                    GroupCourse groupCourse = new GroupCourse(this, course);
-                    groupCourses.add(groupCourse);
-                    course.getGroupCourses().add(groupCourse);
-                });
+        assignCommonCourses();
         return this;
     }
 
@@ -87,5 +82,14 @@ public class StudyGroup extends BaseTime {
                 .map(GroupReport::getTotalMinutes)
                 .mapToLong(Long::longValue)
                 .sum();
+    }
+
+    protected void assignCommonCourses() {
+        getCommonCourses()
+                .forEach(course -> {
+                    GroupCourse groupCourse = new GroupCourse(this, course);
+                    groupCourses.add(groupCourse);
+                    course.getGroupCourses().add(groupCourse);
+                });
     }
 }

--- a/src/main/java/edu/handong/csee/histudy/domain/User.java
+++ b/src/main/java/edu/handong/csee/histudy/domain/User.java
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static java.util.Objects.*;
+import static java.util.Objects.requireNonNullElse;
 
 @Entity
 @Getter
@@ -136,8 +136,12 @@ public class User extends BaseTime {
         return this.studyGroup == null;
     }
 
-    private void leaveGroup() {
+    public void leaveGroup() {
+        if (this.studyGroup == null) {
+            return;
+        }
         this.studyGroup.getMembers().remove(this);
+        this.studyGroup.assignCommonCourses();
         this.studyGroup = null;
         this.role = Role.USER;
     }

--- a/src/main/java/edu/handong/csee/histudy/repository/UserRepository.java
+++ b/src/main/java/edu/handong/csee/histudy/repository/UserRepository.java
@@ -22,10 +22,15 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findUserByEmail(String email);
 
-    List<User> findAllByStudyGroupIsNullAndCourseSelectionsIsNotEmpty();
+    @Query("select u from User u " +
+            "where u.studyGroup is null " +
+            "and u.courseSelections is not empty")
+    List<User> findUnassignedApplicants();
 
-    @Query("select u from User u where u.studyGroup is null and u.courseSelections is not empty")
-    List<User> findUsersByTeamIsNull();
+    @Query("select u from User u " +
+            "where u.studyGroup is null " +
+            "and u.role = 'USER'")
+    List<User> findAllByStudyGroupIsNull();
 
     @Query("select u from User u where u.sub = ?1")
     Optional<User> findUserBySub(String sub);

--- a/src/main/java/edu/handong/csee/histudy/service/TeamService.java
+++ b/src/main/java/edu/handong/csee/histudy/service/TeamService.java
@@ -73,7 +73,7 @@ public class TeamService {
 
     public TeamDto.MatchResults matchTeam() {
         // Get users who are not in a team
-        List<User> users = userRepository.findAllByStudyGroupIsNullAndCourseSelectionsIsNotEmpty();
+        List<User> users = userRepository.findUnassignedApplicants();
         int latestGroupTag = (int) studyGroupRepository.count();
         AtomicInteger tag = new AtomicInteger(latestGroupTag + 1);
 

--- a/src/test/java/edu/handong/csee/histudy/admin/AdminControllerTests.java
+++ b/src/test/java/edu/handong/csee/histudy/admin/AdminControllerTests.java
@@ -119,7 +119,7 @@ public class AdminControllerTests {
         assertEquals(0, res.getCourses().size());
     }
 
-    @DisplayName("그룹 미배정 학생 목록에서 미신청자는 제외되어야 함")
+    @DisplayName("그룹 미배정 학생 목록에서 미신청자도 포함한다")
     @Test
     void AdminControllerTests_122() throws Exception {
         // Given
@@ -163,6 +163,6 @@ public class AdminControllerTests {
                 new TypeReference<>() {
                 });
         // Then
-        assertEquals(1, res.size());
+        assertEquals(2, res.size());
     }
 }

--- a/src/test/java/edu/handong/csee/histudy/user/UserServiceTests.java
+++ b/src/test/java/edu/handong/csee/histudy/user/UserServiceTests.java
@@ -192,7 +192,6 @@ public class UserServiceTests {
                 .priority(0)
                 .build())).toList();
         savedB.getCourseSelections().addAll(choices2);
-        StudyGroup studyGroup = studyGroupRepository.save(new StudyGroup(111, List.of(savedA, savedB)));
         List<UserDto.UserInfo> users = userService.getAppliedUsers();
         assertThat(users.size()).isEqualTo(2);
         System.out.println("users = " + users);


### PR DESCRIPTION
배정된 학생 목록에서 그룹을 변경하거나 미배정 상태로 변경할 수 있음

# 그 외 변경사항
- 신청자 리스트: 스터디 그룹에 신청했으나 배정되지 않은 유저 목록
-> 이 목록에 대한 삭제는 해당 유저의 신청내역을 삭제함

- 미배정 목록: 신청 여부와 관계 없이 그룹이 배정되지 않은 유저 목록
-> 신청하지 않은 유저도 그룹 배정이 가능하나 권장하지 않음 (공통 과목이 부정확해질 수 있음)

- 그룹 공통과목이 중복되어 나타나는 버그 수정
