### PR TITLE
강의 정보 응답에 담당 교수 정보 포함 외 

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -27,7 +27,11 @@ jobs:
 
       - name: Apply configuration
         run: |
-          echo "${{ secrets.APP_CONFIG }}" > ./src/main/resources/application.yml
+          if [ ! -d "./src/test/resources" ]; then
+            mkdir -p ./src/test/resources
+          fi
+        
+          echo "${{ secrets.APP_CONFIG }}" > ./src/test/resources/application.yml
 
       - name: Set JDK 17
         uses: actions/setup-java@v3

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ out/
 /src/main/resources/application.properties
 /**/resources/static/
 htmlReport/
+*.db
+*.yml

--- a/src/main/java/edu/handong/csee/histudy/controller/ApplyFormController.java
+++ b/src/main/java/edu/handong/csee/histudy/controller/ApplyFormController.java
@@ -1,8 +1,14 @@
 package edu.handong.csee.histudy.controller;
 
 import edu.handong.csee.histudy.controller.form.ApplyForm;
+import edu.handong.csee.histudy.controller.form.ApplyFormV2;
+import edu.handong.csee.histudy.domain.Friendship;
 import edu.handong.csee.histudy.domain.Role;
+import edu.handong.csee.histudy.domain.User;
+import edu.handong.csee.histudy.domain.UserCourse;
 import edu.handong.csee.histudy.dto.ApplyFormDto;
+import edu.handong.csee.histudy.dto.CourseDto;
+import edu.handong.csee.histudy.dto.UserDto;
 import edu.handong.csee.histudy.exception.ForbiddenException;
 import edu.handong.csee.histudy.service.UserService;
 import io.jsonwebtoken.Claims;
@@ -11,24 +17,76 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Comparator;
 
 @Tag(name = "스터디 신청 API")
 @SecurityRequirement(name = "USER")
 @RestController
-@RequestMapping("/api/forms")
 @RequiredArgsConstructor
 public class ApplyFormController {
 
     private final UserService userService;
 
+    /**
+     * 스터디 신청 정보를 등록하는 API
+     *
+     * @param form   신청 정보(같이 하고 싶은 학생 목록, 강의 목록)
+     * @param claims 토큰 페이로드
+     * @return 신청 내역
+     * @see #applyForStudy(ApplyFormV2, Claims)
+     * @deprecated 신청한 학생 목록을 보낼 때
+     * 더 이상 학번 정보를 보낼 수 없기 때문에 사용하지 않음
+     */
     @Operation(summary = "스터디 신청")
-    @PostMapping
+    @Deprecated
+    @PostMapping("/api/forms")
     public ResponseEntity<ApplyFormDto> applyForStudy(
             @RequestBody ApplyForm form,
             @RequestAttribute Claims claims) {
         if (Role.isAuthorized(claims, Role.USER)) {
             return ResponseEntity.ok(userService.apply(form, claims.getSubject()));
+        }
+        throw new ForbiddenException();
+    }
+
+    /**
+     * 스터디 신청 정보를 등록하는 API (v2)
+     *
+     * <p>스터디 신청 단계에서 같이할 학생과 강의를 선택하여
+     * 신청 정보를 등록한다.
+     *
+     * @param form   신청 정보(같이 하고 싶은 학생 목록, 강의 목록)
+     * @param claims 토큰 페이로드
+     * @return 신청 내역
+     */
+    @Operation(summary = "스터디 신청")
+    @PostMapping("/api/v2/forms")
+    public ResponseEntity<ApplyFormDto> applyForStudy(
+            @RequestBody ApplyFormV2 form,
+            @RequestAttribute Claims claims) {
+        if (Role.isAuthorized(claims, Role.USER)) {
+            User appliedUser = userService.apply(
+                    form.getFriendIds(), form.getCourseIds(),
+                    claims.getSubject());
+
+            return ResponseEntity.ok(
+                    new ApplyFormDto(
+                            appliedUser.getSentRequests()
+                                    .stream()
+                                    .map(Friendship::getReceived)
+                                    .map(UserDto.UserBasicWithMasking::new)
+                                    .toList(),
+                            appliedUser.getCourseSelections()
+                                    .stream()
+                                    .sorted(Comparator.comparing(UserCourse::getPriority))
+                                    .map(UserCourse::getCourse)
+                                    .map(CourseDto.CourseInfo::new)
+                                    .toList()));
         }
         throw new ForbiddenException();
     }

--- a/src/main/java/edu/handong/csee/histudy/controller/ExceptionController.java
+++ b/src/main/java/edu/handong/csee/histudy/controller/ExceptionController.java
@@ -6,6 +6,7 @@ import edu.handong.csee.histudy.exception.ForbiddenException;
 import edu.handong.csee.histudy.exception.MissingParameterException;
 import edu.handong.csee.histudy.exception.UserNotFoundException;
 import io.jsonwebtoken.JwtException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.util.Arrays;
 
+@Slf4j
 @RestControllerAdvice
 public class ExceptionController {
 
@@ -62,6 +64,7 @@ public class ExceptionController {
 
     @ExceptionHandler(RuntimeException.class)
     public ResponseEntity<ExceptionResponse> runtimeException(RuntimeException e) {
+        log.error("{}({}): {}", e.getMessage(), e.getClass().getName(), Arrays.toString(e.getStackTrace()));
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(ExceptionResponse.builder()
                         .status(HttpStatus.INTERNAL_SERVER_ERROR)

--- a/src/main/java/edu/handong/csee/histudy/controller/form/ApplyFormV2.java
+++ b/src/main/java/edu/handong/csee/histudy/controller/form/ApplyFormV2.java
@@ -1,0 +1,19 @@
+package edu.handong.csee.histudy.controller.form;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import java.util.List;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ApplyFormV2 {
+
+    @Schema(description = "List of friend added to apply form", type = "array", example = "[1, 2]")
+    private List<Long> friendIds;
+
+    @Schema(description = "List of course added to apply form", type = "array", example = "[1, 2]")
+    private List<Long> courseIds;
+}

--- a/src/main/java/edu/handong/csee/histudy/domain/User.java
+++ b/src/main/java/edu/handong/csee/histudy/domain/User.java
@@ -154,4 +154,8 @@ public class User extends BaseTime {
     public boolean isInSameGroup(StudyGroup studyGroup) {
         return this.studyGroup != null && this.studyGroup.equals(studyGroup);
     }
+
+    public String getSidWithMasking() {
+        return this.sid.substring(0, 3) + "****" + this.sid.substring(7);
+    }
 }

--- a/src/main/java/edu/handong/csee/histudy/dto/ApplyFormDto.java
+++ b/src/main/java/edu/handong/csee/histudy/dto/ApplyFormDto.java
@@ -5,6 +5,7 @@ import edu.handong.csee.histudy.domain.User;
 import edu.handong.csee.histudy.domain.UserCourse;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -12,15 +13,17 @@ import java.util.Comparator;
 import java.util.List;
 
 @Getter
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ApplyFormDto {
 
     @Schema(description = "List of friend added to apply form", type = "array")
-    private List<UserDto.UserBasic> friends;
+    private List<? extends UserDto.UserBasic> friends;
 
     @Schema(description = "List of course added to apply form", type = "array")
     private List<CourseDto.CourseInfo> courses;
 
+    @Deprecated
     public ApplyFormDto(User entity) {
         this.friends = entity.getSentRequests()
                 .stream()

--- a/src/main/java/edu/handong/csee/histudy/dto/CourseDto.java
+++ b/src/main/java/edu/handong/csee/histudy/dto/CourseDto.java
@@ -60,9 +60,13 @@ public class CourseDto {
         @Schema(description = "Course Name", example = "Software Engineering")
         private String name;
 
+        @Schema(description = "Course Professor", example = "Prof. John Doe")
+        private String prof;
+
         public BasicCourseInfo(Course course) {
             this.id = course.getId();
             this.name = course.getName();
+            this.prof = course.getProfessor();
         }
     }
 }

--- a/src/main/java/edu/handong/csee/histudy/dto/UserDto.java
+++ b/src/main/java/edu/handong/csee/histudy/dto/UserDto.java
@@ -16,10 +16,11 @@ import java.util.List;
 public class UserDto {
 
     @Schema(description = "List of user", type = "array")
-    private List<UserMatching> users;
+    private List<? extends UserMatching> users;
 
     @Getter
     @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    @Deprecated
     public static class UserMatching {
 
         @Schema(description = "User name", example = "John Doe")
@@ -35,6 +36,26 @@ public class UserDto {
             this.name = user.getName();
             this.sid = user.getSid();
             this.email = user.getEmail();
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class UserMatchingWithMasking extends UserMatching {
+
+        @Schema(description = "User ID", example = "1")
+        private Long id;
+
+        @Schema(description = "User name", example = "John Doe")
+        private String name;
+
+        @Schema(description = "User student ID", example = "223****2")
+        private String sid;
+
+        public UserMatchingWithMasking(User user) {
+            this.id = user.getId();
+            this.name = user.getName();
+            this.sid = user.getSidWithMasking();
         }
     }
 
@@ -78,7 +99,7 @@ public class UserDto {
         private List<UserBasic> friends;
 
         @Schema(description = "list of course added", type = "array")
-        private List<CourseIdNameDto> courses;
+        private List<CourseDto.BasicCourseInfo> courses;
 
         @Schema(description = "student's total minutes studied", type = "number")
         private long totalMinutes;
@@ -95,7 +116,7 @@ public class UserDto {
                     .toList();
             this.courses = user.getCourseSelections().stream()
                     .sorted(Comparator.comparing(UserCourse::getPriority))
-                    .map(c -> new CourseIdNameDto(c.getCourse()))
+                    .map(c -> new CourseDto.BasicCourseInfo(c.getCourse()))
                     .toList();
             this.totalMinutes = user.getReportParticipation().stream()
                     .mapToLong(p -> p.getGroupReport().getTotalMinutes())
@@ -121,6 +142,26 @@ public class UserDto {
         public UserBasic(User user) {
             this.id = user.getId();
             this.sid = user.getSid();
+            this.name = user.getName();
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class UserBasicWithMasking extends UserBasic {
+
+        @Schema(description = "User ID", example = "1")
+        private Long id;
+
+        @Schema(description = "User name", example = "John Doe")
+        private String name;
+
+        @Schema(description = "User student ID", example = "223****2")
+        private String sid;
+
+        public UserBasicWithMasking(User user) {
+            this.id = user.getId();
+            this.sid = user.getSidWithMasking();
             this.name = user.getName();
         }
     }

--- a/src/main/java/edu/handong/csee/histudy/exception/CourseNotFoundException.java
+++ b/src/main/java/edu/handong/csee/histudy/exception/CourseNotFoundException.java
@@ -1,0 +1,7 @@
+package edu.handong.csee.histudy.exception;
+
+public class CourseNotFoundException extends RuntimeException {
+    public CourseNotFoundException() {
+        super("해당 강의를 찾을 수 없습니다.");
+    }
+}

--- a/src/main/java/edu/handong/csee/histudy/service/TeamService.java
+++ b/src/main/java/edu/handong/csee/histudy/service/TeamService.java
@@ -96,18 +96,18 @@ public class TeamService {
                 .toList());
 
         // Third matching
-//        List<StudyGroup> matchedCourseSecond = matchCourseSecond(users, tag);
+        List<StudyGroup> matchedCourseSecond = matchCourseSecond(users, tag);
 
         // Results
         List<StudyGroup> matchedStudyGroups = new ArrayList<>(teamsWithFriends);
         matchedStudyGroups.addAll(teamsWithoutFriends);
-//        matchedStudyGroups.addAll(matchedCourseSecond);
-//
-//        // Remove users who have already been matched
-//        users.removeAll(matchedCourseSecond.stream()
-//                .map(StudyGroup::getMembers)
-//                .flatMap(Collection::stream)
-//                .toList());
+        matchedStudyGroups.addAll(matchedCourseSecond);
+
+        // Remove users who have already been matched
+        users.removeAll(matchedCourseSecond.stream()
+                .map(StudyGroup::getMembers)
+                .flatMap(Collection::stream)
+                .toList());
 
         return new TeamDto.MatchResults(matchedStudyGroups, userService.getInfoFromUser(users));
     }

--- a/src/main/java/edu/handong/csee/histudy/service/UserService.java
+++ b/src/main/java/edu/handong/csee/histudy/service/UserService.java
@@ -58,6 +58,32 @@ public class UserService {
         return new ApplyFormDto(user);
     }
 
+    public User apply(
+            List<Long> friendsIds,
+            List<Long> courseIds,
+            String email
+    ) {
+        List<User> friends = friendsIds
+                .stream()
+                .map(id ->
+                        userRepository.findById(id)
+                                .orElseThrow(UserNotFoundException::new))
+                .toList();
+        List<Course> courses = courseIds
+                .stream()
+                .map(id ->
+                        courseRepository.findById(id)
+                                .orElseThrow(CourseNotFoundException::new))
+                .toList();
+
+        User user = userRepository.findUserByEmail(email)
+                .orElseThrow(UserNotFoundException::new);
+        user.addUser(friends);
+        user.selectCourse(courses);
+
+        return user;
+    }
+
     public void signUp(UserForm userForm) {
         userRepository
                 .findUserBySub(userForm.getSub())
@@ -99,10 +125,9 @@ public class UserService {
                 .toList();
     }
 
-    public ApplyFormDto getUserInfo(String email) {
-        User user = userRepository.findUserByEmail(email)
+    public User getUserInfo(String email) {
+        return userRepository.findUserByEmail(email)
                 .orElseThrow(UserNotFoundException::new);
-        return new ApplyFormDto(user);
     }
 
     public UserDto.UserMe getUserMe(Optional<String> emailOr) {

--- a/src/test/java/edu/handong/csee/histudy/admin/AdminControllerTests.java
+++ b/src/test/java/edu/handong/csee/histudy/admin/AdminControllerTests.java
@@ -38,7 +38,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@ActiveProfiles("dev")
 @Transactional
 public class AdminControllerTests {
 

--- a/src/test/java/edu/handong/csee/histudy/algo/MatchingAlgorithmTests.java
+++ b/src/test/java/edu/handong/csee/histudy/algo/MatchingAlgorithmTests.java
@@ -22,7 +22,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@ActiveProfiles("dev")
 @SpringBootTest
 @Transactional
 public class MatchingAlgorithmTests {

--- a/src/test/java/edu/handong/csee/histudy/course/CourseControllerTests.java
+++ b/src/test/java/edu/handong/csee/histudy/course/CourseControllerTests.java
@@ -31,7 +31,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@ActiveProfiles("dev")
 @AutoConfigureMockMvc
 @SpringBootTest
 @Transactional

--- a/src/test/java/edu/handong/csee/histudy/group/ReportGroupCourseControllerTests.java
+++ b/src/test/java/edu/handong/csee/histudy/group/ReportGroupCourseControllerTests.java
@@ -36,7 +36,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@ActiveProfiles("dev")
 @AutoConfigureMockMvc
 @SpringBootTest
 @Transactional

--- a/src/test/java/edu/handong/csee/histudy/report/ReportCourseReportControllerTestsGroup.java
+++ b/src/test/java/edu/handong/csee/histudy/report/ReportCourseReportControllerTestsGroup.java
@@ -36,7 +36,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@ActiveProfiles("dev")
 @AutoConfigureMockMvc
 @SpringBootTest
 @Transactional

--- a/src/test/java/edu/handong/csee/histudy/report/ReportCourseReportServiceTestGroup.java
+++ b/src/test/java/edu/handong/csee/histudy/report/ReportCourseReportServiceTestGroup.java
@@ -21,7 +21,6 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@ActiveProfiles("dev")
 @SpringBootTest
 @Transactional
 public class ReportCourseReportServiceTestGroup {

--- a/src/test/java/edu/handong/csee/histudy/user/UserControllerTests.java
+++ b/src/test/java/edu/handong/csee/histudy/user/UserControllerTests.java
@@ -37,7 +37,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@ActiveProfiles("dev")
 @AutoConfigureMockMvc
 @SpringBootTest
 @Transactional

--- a/src/test/java/edu/handong/csee/histudy/user/UserServiceTests.java
+++ b/src/test/java/edu/handong/csee/histudy/user/UserServiceTests.java
@@ -26,7 +26,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
-@ActiveProfiles("dev")
 @SpringBootTest
 @Transactional
 public class UserServiceTests {

--- a/src/test/java/edu/handong/csee/integration/ReportTests.java
+++ b/src/test/java/edu/handong/csee/integration/ReportTests.java
@@ -51,7 +51,7 @@ public class ReportTests {
 
     @DisplayName("관리자 권한으로 보고서를 열람할 수 있어야 함")
     @Test
-    void ReportTests_18(@Value("${custom.jwt.secret.admin}") String adminToken) throws Exception {
+    void ReportTests_18(@Value("${custom.jwt.example.admin}") String adminToken) throws Exception {
         // Given
         User writer = User.builder()
                 .sub("123")

--- a/src/test/java/edu/handong/csee/integration/UserTests.java
+++ b/src/test/java/edu/handong/csee/integration/UserTests.java
@@ -43,7 +43,7 @@ public class UserTests {
     @Autowired
     ObjectMapper objectMapper;
 
-    @Value("${custom.jwt.secret.user}")
+    @Value("${custom.jwt.example.user}")
     String userToken;
     @Autowired
     private UserRepository userRepository;


### PR DESCRIPTION
- [x] 학번 마스킹 처리
* `GET /api/v2/users` -> 유저 검색
* `GET /api/v2/users/me/forms` -> 내 스터디 신청 정보 조회
- [x] 스터디 신청시 학번이 아닌 아이디를 요청에 포함하도록
* `POST /api/v2/forms`
- [x] 강의 정보 조회시 담당 교수 정보도 반환
- [x] 테스트 프로파일 분리