### PR TITLE
뒤늦게 신청한 상대의 친구 선택 상태가 변경되지 않는 버그 수정

### DIFF
--- a/src/main/java/edu/handong/csee/histudy/domain/StudyApplicant.java
+++ b/src/main/java/edu/handong/csee/histudy/domain/StudyApplicant.java
@@ -48,7 +48,7 @@ public class StudyApplicant extends BaseTime {
     return applicant;
   }
 
-  public void changeStatusIfPartnerRequested(
+  public void changeStatusIfReceivedBy(
       User user, Function<StudyPartnerRequest, RequestStatus> changeStatus) {
     this.partnerRequests.stream()
         .filter(request -> request.isReceivedBy(user))

--- a/src/main/java/edu/handong/csee/histudy/domain/StudyGroup.java
+++ b/src/main/java/edu/handong/csee/histudy/domain/StudyGroup.java
@@ -113,10 +113,7 @@ public class StudyGroup extends BaseTime {
   }
 
   protected void assignCommonCourses(StudyApplicant... applicants) {
-    if (isSameMemberExact(applicants)) return;
-    if (this.members.isEmpty()) {
-      this.courses.clear();
-      this.tag = -1;
+    if (isSameMemberExact(applicants)) {
       return;
     }
     findCommonCourses(applicants).stream()

--- a/src/main/java/edu/handong/csee/histudy/repository/StudyGroupRepository.java
+++ b/src/main/java/edu/handong/csee/histudy/repository/StudyGroupRepository.java
@@ -16,8 +16,8 @@ public interface StudyGroupRepository extends JpaRepository<StudyGroup, Long> {
   Optional<StudyGroup> findByTagAndAcademicTerm(int tag, AcademicTerm academicTerm);
 
   @Modifying
-  @Query("delete from StudyGroup s where s.tag = -1")
-  void deleteEmptyGroup();
+  @Query("delete from StudyGroup s where s.members is empty and s.academicTerm = :academicTerm")
+  void deleteEmptyGroup(@Param("academicTerm") AcademicTerm academicTerm);
 
   @Query("select max(s.tag) from StudyGroup s where s.academicTerm = :academicTerm")
   Optional<Integer> countMaxTag(@Param("academicTerm") AcademicTerm academicTerm);

--- a/src/main/java/edu/handong/csee/histudy/service/UserService.java
+++ b/src/main/java/edu/handong/csee/histudy/service/UserService.java
@@ -228,7 +228,7 @@ public class UserService {
                 applicantOr.ifPresent(
                     applicant -> {
                       applicant.leaveGroup();
-                      studyGroupRepository.deleteEmptyGroup();
+                      studyGroupRepository.deleteEmptyGroup(currentTerm);
                     }));
   }
 

--- a/src/main/java/edu/handong/csee/histudy/service/UserService.java
+++ b/src/main/java/edu/handong/csee/histudy/service/UserService.java
@@ -57,9 +57,12 @@ public class UserService {
             studyApplicantRepository
                 .findByUserAndTerm(partner, currentTerm)
                 .ifPresent(
-                    partnerApplication ->
-                        partnerApplication.changeStatusIfPartnerRequested(
-                            user, StudyPartnerRequest::accept)));
+                    partnerApplication -> {
+                      partnerApplication.changeStatusIfReceivedBy(
+                          user, StudyPartnerRequest::accept);
+
+                      applicant.changeStatusIfReceivedBy(partner, StudyPartnerRequest::accept);
+                    }));
     studyApplicantRepository.save(applicant);
     return new ApplyFormDto(applicant);
   }
@@ -88,9 +91,12 @@ public class UserService {
             studyApplicantRepository
                 .findByUserAndTerm(partner, currentTerm)
                 .ifPresent(
-                    partnerApplication ->
-                        partnerApplication.changeStatusIfPartnerRequested(
-                            user, StudyPartnerRequest::accept)));
+                    partnerApplication -> {
+                      partnerApplication.changeStatusIfReceivedBy(
+                          user, StudyPartnerRequest::accept);
+
+                      applicant.changeStatusIfReceivedBy(partner, StudyPartnerRequest::accept);
+                    }));
     return studyApplicantRepository.save(applicant);
   }
 
@@ -109,7 +115,7 @@ public class UserService {
                     .findByUserAndTerm(receiver, currentTerm)
                     .ifPresent(
                         partnerApplication ->
-                            partnerApplication.changeStatusIfPartnerRequested(
+                            partnerApplication.changeStatusIfReceivedBy(
                                 user, StudyPartnerRequest::unfriend));
               }
               studyApplicantRepository.delete(applicant);


### PR DESCRIPTION
원인 :

모든 친구 선택 신청 상태의 기본값은 `PENDING`인데 스터디 신청시 내가 선택한 파트너가 나를 이미 선택한 경우 파트너의 친구 선택 상태는 변경 했는데 정작 자기 자신의 선택 상태는 변경하지 않았다.

+ 관리자 모드에서 그룹 인원 변동할 때 멤버가 없는 빈 그룹이 발생하면 삭제하도록 되어 있는데, 기존 로직 상 그 부분이 트리거 될 수 없어서 이 부분도 수정.