### PR TITLE
fix(reports): handle oversized image uploads with 413

### DIFF
--- a/src/main/java/edu/handong/csee/histudy/controller/ExceptionController.java
+++ b/src/main/java/edu/handong/csee/histudy/controller/ExceptionController.java
@@ -27,11 +27,15 @@ import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
+import org.springframework.web.multipart.MultipartException;
 
 @Slf4j
 @RestControllerAdvice
 @RequiredArgsConstructor
 public class ExceptionController {
+
+  private static final String EXCEED_MAX_FILE_SIZE = "EXCEED_MAX_FILE_SIZE";
 
   private final DiscordService discordService;
 
@@ -53,6 +57,20 @@ public class ExceptionController {
   public ResponseEntity<ExceptionResponse> handleHttpMessageNotReadable(
       HttpMessageNotReadableException e) {
     return createErrorResponse(HttpStatus.BAD_REQUEST, "Invalid request format");
+  }
+
+  @ExceptionHandler(MaxUploadSizeExceededException.class)
+  public ResponseEntity<ExceptionResponse> handleMaxUploadSizeExceeded(
+      MaxUploadSizeExceededException e) {
+    return createErrorResponse(HttpStatus.PAYLOAD_TOO_LARGE, EXCEED_MAX_FILE_SIZE);
+  }
+
+  @ExceptionHandler(MultipartException.class)
+  public ResponseEntity<ExceptionResponse> handleMultipartException(MultipartException e) {
+    if (isSizeLimitExceeded(e)) {
+      return createErrorResponse(HttpStatus.PAYLOAD_TOO_LARGE, EXCEED_MAX_FILE_SIZE);
+    }
+    return createErrorResponse(HttpStatus.BAD_REQUEST, "Invalid multipart request");
   }
 
   @ExceptionHandler({JwtException.class, MissingTokenException.class})
@@ -87,6 +105,27 @@ public class ExceptionController {
   @ExceptionHandler({DuplicateAcademicTermException.class, UserAlreadyExistsException.class})
   public ResponseEntity<ExceptionResponse> handleConflict(Exception e) {
     return createErrorResponse(HttpStatus.CONFLICT, e.getMessage());
+  }
+
+  private boolean isSizeLimitExceeded(Throwable throwable) {
+    Throwable current = throwable;
+    while (current != null) {
+      if (current instanceof MaxUploadSizeExceededException) {
+        return true;
+      }
+      String message = current.getMessage();
+      if (message != null) {
+        String normalized = message.toLowerCase();
+        if (normalized.contains("maximum upload size")
+            || normalized.contains("maxuploadsizeexceeded")
+            || normalized.contains("size limit exceeded")
+            || normalized.contains("exceeds its maximum permitted size")) {
+          return true;
+        }
+      }
+      current = current.getCause();
+    }
+    return false;
   }
 
   @ExceptionHandler(RuntimeException.class)

--- a/src/test/java/edu/handong/csee/histudy/controller/TeamControllerTest.java
+++ b/src/test/java/edu/handong/csee/histudy/controller/TeamControllerTest.java
@@ -34,6 +34,7 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 @WebMvcTest(TeamController.class)
 class TeamControllerTest {
@@ -262,6 +263,24 @@ class TeamControllerTest {
         .andExpect(status().isOk())
         .andExpect(content().contentType("application/json"))
         .andExpect(jsonPath("$.imagePath").value(imagePath));
+  }
+
+  @Test
+  void 그룹원이_파일용량초과_보고서이미지업로드시_413응답() throws Exception {
+    Claims claims = memberClaims("member@test.com");
+
+    MockMultipartFile image =
+        new MockMultipartFile("image", "test.jpg", "image/jpeg", "test image content".getBytes());
+
+    when(imageService.getImagePaths(anyString(), any(), any(Optional.class)))
+        .thenThrow(new MaxUploadSizeExceededException(1024));
+
+    mockMvc
+        .perform(multipart("/api/team/reports/image").file(image).requestAttr("claims", claims))
+        .andExpect(status().isPayloadTooLarge())
+        .andExpect(content().contentType("application/json"))
+        .andExpect(jsonPath("$.code").value(413))
+        .andExpect(jsonPath("$.message").value("EXCEED_MAX_FILE_SIZE"));
   }
 
   @Test


### PR DESCRIPTION
- 보고서 이미지 업로드 용량 초과를 413 응답으로 표준화
  > 보고서 이미지 업로드에서 파일 크기 제한을 넘길 때 서버 내부 오류처럼 보이던 흐름을 명시적인 클라이언트 오류로 바꿨습니다. `MaxUploadSizeExceededException`과 래핑된 `MultipartException`을 함께 처리해 업로드 스택 차이에도 동일한 응답을 보장합니다. 응답 메시지를 `EXCEED_MAX_FILE_SIZE`로 고정해 클라이언트가 재시도나 사용자 안내를 일관되게 구현할 수 있게 했습니다. 이 변경으로 대용량 이미지 업로드 실패 원인이 사용자에게 더 분명하게 전달됩니다.

- 파일 용량 초과 시나리오에 대한 컨트롤러 테스트를 추가
  > 이미지 업로드 경계 조건은 배포 후에야 드러나기 쉬워 회귀 테스트가 필요했습니다. 컨트롤러 테스트에서 이미지 서비스가 업로드 크기 초과 예외를 던지는 상황을 직접 재현해 413 상태 코드와 에러 메시지를 검증했습니다. 이를 통해 예외 처리기 수정이나 업로드 경로 변경이 있어도 기대 계약이 유지되는지 빠르게 확인할 수 있습니다. 운영 중 동일 문제가 다시 섞여 들어오는 위험을 낮추는 목적도 있습니다.
