### PR TITLE
fix: 이미지 업로드 용량 초과 처리

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,9 @@
 ## 문맥 지도
 
 - `docs/domain.md`: 용어, 엔티티, 불변 조건, 매칭 규칙, 프라이버시 규칙, 리포트/이미지 의미론
-- `docs/architecture.md`: 패키지 책임, 요청 흐름, 인증 모델, API 표면, 테스트 구조
-- `docs/workflows.md`: 반복 작업 절차, 설정 경로, 운영 가드레일, 하니스 갱신 조건
-- `docs/acceptance-criteria.md`: 기능별 성공 조건, 실패 조건, 테스트에서 확인해야 할 인수 기준
+- `docs/architecture.md`: 패키지 책임, 요청 흐름, 인증 모델, API 표면, 테스트 배치의 큰 구조
+- `docs/test/user-story.md`: 테스트 대상 유저 스토리와 도메인별 인수 조건의 출발점
+- `docs/test/structure.md`: 테스트 파일 위치, 프로퍼티 배치, 테스트 메서드 네이밍과 작성 형식
 
 ## 작업 규칙
 
@@ -21,7 +21,8 @@
 - `controller -> service -> repository` 분리를 유지합니다.
 - 컨트롤러는 얇게 유지하고, 비즈니스 결정은 리포지토리로 내리지 않습니다.
 - API 경계는 DTO/form으로 유지하고, 도메인 엔티티를 직접 노출하지 않습니다.
-- 테스트를 추가하거나 수정할 때는 `docs/acceptance-criteria.md`를 먼저 확인합니다.
+- 테스트를 추가하거나 수정할 때는 먼저 `docs/test/user-story.md`에서 유저 스토리를 확인합니다.
+- 테스트 코드는 `docs/test/structure.md`의 파일 위치, 프로퍼티 순서, 메서드 네이밍, given-when-then 형식을 따릅니다.
 - 지속적 맥락이 바뀌면 해당 `docs/*.md`를 먼저 갱신하고, 탐색 구조가 바뀐 경우에만 `AGENTS.md`를 수정합니다.
 
 ## 빠른 명령어

--- a/src/main/java/edu/handong/csee/histudy/controller/ExceptionController.java
+++ b/src/main/java/edu/handong/csee/histudy/controller/ExceptionController.java
@@ -27,6 +27,7 @@ import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 @Slf4j
 @RestControllerAdvice
@@ -53,6 +54,13 @@ public class ExceptionController {
   public ResponseEntity<ExceptionResponse> handleHttpMessageNotReadable(
       HttpMessageNotReadableException e) {
     return createErrorResponse(HttpStatus.BAD_REQUEST, "Invalid request format");
+  }
+
+  @ExceptionHandler(MaxUploadSizeExceededException.class)
+  public ResponseEntity<ExceptionResponse> handleMaxUploadSizeExceeded(
+      MaxUploadSizeExceededException e) {
+    return createErrorResponse(
+        HttpStatus.PAYLOAD_TOO_LARGE, "업로드 가능한 파일 용량을 초과했습니다.");
   }
 
   @ExceptionHandler({JwtException.class, MissingTokenException.class})

--- a/src/test/java/edu/handong/csee/histudy/controller/TeamControllerTest.java
+++ b/src/test/java/edu/handong/csee/histudy/controller/TeamControllerTest.java
@@ -34,6 +34,7 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 @WebMvcTest(TeamController.class)
 class TeamControllerTest {
@@ -262,6 +263,25 @@ class TeamControllerTest {
         .andExpect(status().isOk())
         .andExpect(content().contentType("application/json"))
         .andExpect(jsonPath("$.imagePath").value(imagePath));
+  }
+
+  @Test
+  void 그룹원이_용량초과_보고서이미지업로드시_실패() throws Exception {
+    Claims claims = memberClaims("member@test.com");
+
+    MockMultipartFile image =
+        new MockMultipartFile("image", "test.jpg", "image/jpeg", "test image content".getBytes());
+
+    when(imageService.getImagePaths(anyString(), any(), any(Optional.class)))
+        .thenThrow(new MaxUploadSizeExceededException(5 * 1024 * 1024));
+
+    mockMvc
+        .perform(multipart("/api/team/reports/image").file(image).requestAttr("claims", claims))
+        .andExpect(status().isPayloadTooLarge())
+        .andExpect(content().contentType("application/json"))
+        .andExpect(jsonPath("$.code").value(413))
+        .andExpect(jsonPath("$.error").value("Payload Too Large"))
+        .andExpect(jsonPath("$.message").value("업로드 가능한 파일 용량을 초과했습니다."));
   }
 
   @Test


### PR DESCRIPTION
- 보고서 이미지 업로드 용량 초과를 413 응답으로 처리
  > 보고서 이미지 업로드가 제한 용량을 넘길 때 기존에는 클라이언트가 일관된 API 오류를 받기 어려웠습니다. 이번 변경으로 업로드 크기 초과 예외를 전역 예외 처리기에서 받아 `413 Payload Too Large`와 명확한 한글 메시지로 응답합니다. 클라이언트는 상태 코드와 메시지를 기준으로 재시도나 사용자 안내를 안정적으로 분기할 수 있습니다. 업로드 실패 상황이 서버 내부 오류처럼 보이지 않도록 API 경계를 명확히 하는 목적도 있습니다.

- 팀 보고서 이미지 업로드 경계 테스트를 추가
  > 컨트롤러 테스트에서 용량 초과 상황을 직접 재현해 실제 응답 코드와 에러 본문을 검증하도록 보강했습니다. 이를 통해 예외 처리 로직이 바뀌더라도 업로드 제한 정책이 의도한 형태로 유지되는지 빠르게 확인할 수 있습니다. 특히 그룹원 보고서 이미지 업로드 경로에서 발생하는 실패 케이스를 고정해 회귀를 막는 데 초점을 맞췄습니다. 사용자 관점에서 보이는 계약을 테스트로 남겨 변경 안정성을 높였습니다.

- AGENTS 문서의 테스트 안내를 현재 구조에 맞게 정리
  > 저장소 탐색 문서가 실제 테스트 문서 위치와 작성 규칙을 바로 가리키도록 정리했습니다. 테스트 작업 시 참고해야 할 유저 스토리 문서와 구조 가이드를 분리해 후속 변경자가 더 빠르게 기준 문서를 찾을 수 있게 했습니다. 이는 이번 테스트 추가 작업과도 맞물려, 구현과 문서 기준이 어긋나지 않도록 유지하려는 목적이 있습니다. 문서 갱신 범위는 탐색 레이어에 한정해 제품 의도 문서와의 역할도 유지했습니다.
