### PR TITLE
컨트롤러의 리포지토리 직접 의존 제거

### DIFF
--- a/src/main/java/edu/handong/csee/histudy/controller/TeamController.java
+++ b/src/main/java/edu/handong/csee/histudy/controller/TeamController.java
@@ -6,9 +6,6 @@ import edu.handong.csee.histudy.dto.CourseDto;
 import edu.handong.csee.histudy.dto.ReportDto;
 import edu.handong.csee.histudy.dto.UserDto;
 import edu.handong.csee.histudy.exception.ForbiddenException;
-import edu.handong.csee.histudy.repository.AcademicTermRepository;
-import edu.handong.csee.histudy.repository.StudyGroupRepository;
-import edu.handong.csee.histudy.repository.UserRepository;
 import edu.handong.csee.histudy.service.CourseService;
 import edu.handong.csee.histudy.service.ImageService;
 import edu.handong.csee.histudy.service.ReportService;
@@ -31,9 +28,6 @@ public class TeamController {
   private final CourseService courseService;
   private final TeamService teamService;
   private final ImageService imageService;
-  private final UserRepository userRepository;
-  private final AcademicTermRepository academicTermRepository;
-  private final StudyGroupRepository studyGroupRepository;
 
   @PostMapping("/reports")
   public ReportDto.ReportInfo createReport(

--- a/src/test/java/edu/handong/csee/histudy/architecture/LayerDependencyTest.java
+++ b/src/test/java/edu/handong/csee/histudy/architecture/LayerDependencyTest.java
@@ -14,12 +14,16 @@ class LayerDependencyTest {
 
   private static final Path MAIN_SOURCE_DIRECTORY =
       Path.of("src/main/java/edu/handong/csee/histudy");
+  private static final Path CONTROLLER_SOURCE_DIRECTORY =
+      MAIN_SOURCE_DIRECTORY.resolve("controller");
+  private static final String REPOSITORY_PACKAGE_PREFIX =
+      "edu.handong.csee.histudy.repository.";
   private static final List<String> FORBIDDEN_DEPENDENCY_PREFIXES =
       List.of(
-          "edu.handong.csee.histudy.controller",
-          "edu.handong.csee.histudy.dto",
-          "edu.handong.csee.histudy.repository",
-          "edu.handong.csee.histudy.service");
+          "edu.handong.csee.histudy.controller.",
+          "edu.handong.csee.histudy.dto.",
+          REPOSITORY_PACKAGE_PREFIX,
+          "edu.handong.csee.histudy.service.");
 
   @Test
   void 도메인계층은_외부레이어에_의존하지_않는다() throws IOException {
@@ -41,6 +45,29 @@ class LayerDependencyTest {
                 source ->
                     readLines(source)
                         .filter(LayerDependencyTest::isForbiddenDependency)
+                        .map(line -> source + ": " + line))
+            .toList();
+
+    // Then
+    assertThat(forbiddenDependencies).isEmpty();
+  }
+
+  @Test
+  void 컨트롤러계층은_리포지토리에_직접의존하지_않는다() throws IOException {
+    // Given
+    List<Path> controllerSources;
+    try (Stream<Path> paths = Files.walk(CONTROLLER_SOURCE_DIRECTORY)) {
+      controllerSources =
+          paths.filter(path -> path.toString().endsWith(".java")).sorted().toList();
+    }
+
+    // When
+    List<String> forbiddenDependencies =
+        controllerSources.stream()
+            .flatMap(
+                source ->
+                    readLines(source)
+                        .filter(line -> line.contains(REPOSITORY_PACKAGE_PREFIX))
                         .map(line -> source + ": " + line))
             .toList();
 

--- a/src/test/java/edu/handong/csee/histudy/architecture/LayerDependencyTest.java
+++ b/src/test/java/edu/handong/csee/histudy/architecture/LayerDependencyTest.java
@@ -67,7 +67,7 @@ class LayerDependencyTest {
             .flatMap(
                 source ->
                     readLines(source)
-                        .filter(line -> line.contains(REPOSITORY_PACKAGE_PREFIX))
+                        .filter(LayerDependencyTest::isRepositoryDependency)
                         .map(line -> source + ": " + line))
             .toList();
 
@@ -85,6 +85,36 @@ class LayerDependencyTest {
 
     // Then
     assertThat(forbiddenDependency).isTrue();
+  }
+
+  @Test
+  void 주석에_리포지토리패키지명이_있으면_직접의존으로_탐지하지않는다() {
+    // Given
+    List<String> commentLines =
+        List.of(
+            "// " + REPOSITORY_PACKAGE_PREFIX,
+            "/* " + REPOSITORY_PACKAGE_PREFIX,
+            "* " + REPOSITORY_PACKAGE_PREFIX);
+
+    // When
+    List<String> repositoryDependencies =
+        commentLines.stream().filter(LayerDependencyTest::isRepositoryDependency).toList();
+
+    // Then
+    assertThat(repositoryDependencies).isEmpty();
+  }
+
+  @Test
+  void FQCN으로_리포지토리를_참조하면_직접의존으로_탐지한다() {
+    // Given
+    String codeLine =
+        "private edu.handong.csee.histudy.repository.UserRepository userRepository;";
+
+    // When
+    boolean repositoryDependency = isRepositoryDependency(codeLine);
+
+    // Then
+    assertThat(repositoryDependency).isTrue();
   }
 
   @Test
@@ -111,7 +141,16 @@ class LayerDependencyTest {
   }
 
   private static boolean isForbiddenDependency(String line) {
-    return FORBIDDEN_DEPENDENCY_PREFIXES.stream().anyMatch(line::contains);
+    return isSourceCodeLine(line)
+        && FORBIDDEN_DEPENDENCY_PREFIXES.stream().anyMatch(line::contains);
+  }
+
+  private static boolean isRepositoryDependency(String line) {
+    return isSourceCodeLine(line) && line.contains(REPOSITORY_PACKAGE_PREFIX);
+  }
+
+  private static boolean isSourceCodeLine(String line) {
+    return !line.startsWith("//") && !line.startsWith("/*") && !line.startsWith("*");
   }
 
   private static boolean isDomainSource(Path source) {

--- a/src/test/java/edu/handong/csee/histudy/controller/TeamControllerTest.java
+++ b/src/test/java/edu/handong/csee/histudy/controller/TeamControllerTest.java
@@ -13,9 +13,6 @@ import edu.handong.csee.histudy.dto.CourseDto;
 import edu.handong.csee.histudy.dto.ReportDto;
 import edu.handong.csee.histudy.dto.UserDto;
 import edu.handong.csee.histudy.interceptor.AuthenticationInterceptor;
-import edu.handong.csee.histudy.repository.AcademicTermRepository;
-import edu.handong.csee.histudy.repository.StudyGroupRepository;
-import edu.handong.csee.histudy.repository.UserRepository;
 import edu.handong.csee.histudy.service.CourseService;
 import edu.handong.csee.histudy.service.DiscordService;
 import edu.handong.csee.histudy.service.ImageService;
@@ -53,12 +50,6 @@ class TeamControllerTest {
 
   @MockitoBean private ImageService imageService;
 
-  @MockitoBean private UserRepository userRepository;
-
-  @MockitoBean private AcademicTermRepository academicTermRepository;
-
-  @MockitoBean private StudyGroupRepository studyGroupRepository;
-
   @MockitoBean private JwtService jwtService;
 
   @MockitoBean private DiscordService discordService;
@@ -73,10 +64,7 @@ class TeamControllerTest {
                     reportService,
                     courseService,
                     teamService,
-                    imageService,
-                    userRepository,
-                    academicTermRepository,
-                    studyGroupRepository))
+                    imageService))
             .setControllerAdvice(new ExceptionController(discordService))
             .addInterceptors(authenticationInterceptor)
             .build();


### PR DESCRIPTION
1. `TeamController`에 남아 있던 미사용 리포지토리 의존 제거

> 컨트롤러가 HTTP 요청·응답 경계와 서비스 호출에 집중하도록 `UserRepository`, `AcademicTermRepository`, `StudyGroupRepository` 주입을 제거했습니다. 실제 리포지토리 호출은 없었으므로 API와 런타임 동작은 변경하지 않습니다. 점진적 모듈화의 첫 단계로 기존 `controller -> service -> repository` 의존 방향을 코드에 명확히 드러내기 위한 변경입니다.

2. 컨트롤러 계층의 리포지토리 직접 의존을 감지하는 아키텍처 테스트 추가

> 현재의 논리적 패키지 경계가 이후 변경에서 다시 무너지지 않도록 컨트롤러 소스가 리포지토리 패키지를 직접 참조하면 실패하는 회귀 테스트를 추가했습니다. 모듈 경계를 한 번에 강제하기보다 현재 합의된 레이어 경계부터 작은 단위로 보호하려는 의도입니다. 실제 FQCN 참조도 탐지해 import 외의 직접 의존 역시 방지합니다.

3. 아키텍처 테스트의 주석 오탐 방지

> 리뷰에서 확인된 문자열 검사 방식의 오탐 가능성을 줄이기 위해 주석 라인은 실제 의존으로 판단하지 않도록 보완했습니다. 주석의 패키지명은 무시하고 실제 리포지토리 FQCN은 탐지하는 양방향 회귀 테스트를 추가했습니다. ArchUnit 도입은 기능별 패키지 경계와 규칙이 확장되는 후속 PR에서 다시 검토합니다.

4. 컨트롤러 테스트 구성 정리 및 전체 회귀 검증

> 제거된 생성자 의존에 맞춰 `TeamControllerTest`의 불필요한 리포지토리 목을 정리했습니다. `./gradlew test --rerun-tasks` 전체 테스트를 통과해 기존 기능에 대한 회귀가 없음을 확인했습니다. 변경은 테스트 판별 기준과 미사용 의존 정리에 한정되므로 API 계약과 런타임 동작은 유지됩니다.
