### PR TITLE
스터디 신청 서비스의 HTTP 요청 객체 의존 제거

### DIFF
--- a/src/main/java/edu/handong/csee/histudy/controller/ApplyFormController.java
+++ b/src/main/java/edu/handong/csee/histudy/controller/ApplyFormController.java
@@ -8,6 +8,7 @@ import edu.handong.csee.histudy.dto.CourseDto;
 import edu.handong.csee.histudy.dto.UserDto;
 import edu.handong.csee.histudy.exception.ForbiddenException;
 import edu.handong.csee.histudy.service.UserService;
+import edu.handong.csee.histudy.service.command.LegacyStudyApplicationCommand;
 import io.jsonwebtoken.Claims;
 import java.util.Comparator;
 import lombok.RequiredArgsConstructor;
@@ -37,7 +38,9 @@ public class ApplyFormController {
   public ResponseEntity<ApplyFormDto> applyForStudy(
       @RequestBody ApplyForm form, @RequestAttribute Claims claims) {
     if (Role.isAuthorized(claims, Role.USER)) {
-      return ResponseEntity.ok(userService.apply(form, claims.getSubject()));
+      LegacyStudyApplicationCommand command =
+          new LegacyStudyApplicationCommand(form.getFriendIds(), form.getCourseIds());
+      return ResponseEntity.ok(userService.apply(command, claims.getSubject()));
     }
     throw new ForbiddenException();
   }

--- a/src/main/java/edu/handong/csee/histudy/service/UserService.java
+++ b/src/main/java/edu/handong/csee/histudy/service/UserService.java
@@ -1,6 +1,5 @@
 package edu.handong.csee.histudy.service;
 
-import edu.handong.csee.histudy.controller.form.ApplyForm;
 import edu.handong.csee.histudy.controller.form.UserForm;
 import edu.handong.csee.histudy.domain.*;
 import edu.handong.csee.histudy.dto.ApplyFormDto;
@@ -8,6 +7,7 @@ import edu.handong.csee.histudy.dto.UserDto;
 import edu.handong.csee.histudy.exception.*;
 import edu.handong.csee.histudy.repository.*;
 import edu.handong.csee.histudy.repository.StudyApplicantRepository;
+import edu.handong.csee.histudy.service.command.LegacyStudyApplicationCommand;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -33,7 +33,7 @@ public class UserService {
     return userRepository.findUserByNameOrSidOrEmail(keyword.get());
   }
 
-  public ApplyFormDto apply(ApplyForm form, String email) {
+  public ApplyFormDto apply(LegacyStudyApplicationCommand command, String email) {
     AcademicTerm currentTerm =
         academicTermRepository.findCurrentSemester().orElseThrow(NoCurrentTermFoundException::new);
     User user = userRepository.findUserByEmail(email).orElseThrow(UserNotFoundException::new);
@@ -41,12 +41,12 @@ public class UserService {
     removeFormHistoryIfExists(user, currentTerm);
 
     List<User> partners =
-        form.getFriendIds().stream()
+        command.friendStudentIds().stream()
             .map(sid -> userRepository.findUserBySid(sid).orElseThrow(UserNotFoundException::new))
             .toList();
 
     List<Course> courses =
-        form.getCourseIds().stream()
+        command.courseIds().stream()
             .map(id -> courseRepository.findById(id).orElseThrow(CourseNotFoundException::new))
             .toList();
 

--- a/src/main/java/edu/handong/csee/histudy/service/command/LegacyStudyApplicationCommand.java
+++ b/src/main/java/edu/handong/csee/histudy/service/command/LegacyStudyApplicationCommand.java
@@ -3,4 +3,10 @@ package edu.handong.csee.histudy.service.command;
 import java.util.List;
 
 public record LegacyStudyApplicationCommand(
-    List<String> friendStudentIds, List<Long> courseIds) {}
+    List<String> friendStudentIds, List<Long> courseIds) {
+
+  public LegacyStudyApplicationCommand {
+    friendStudentIds = friendStudentIds == null ? List.of() : List.copyOf(friendStudentIds);
+    courseIds = courseIds == null ? List.of() : List.copyOf(courseIds);
+  }
+}

--- a/src/main/java/edu/handong/csee/histudy/service/command/LegacyStudyApplicationCommand.java
+++ b/src/main/java/edu/handong/csee/histudy/service/command/LegacyStudyApplicationCommand.java
@@ -1,0 +1,6 @@
+package edu.handong.csee.histudy.service.command;
+
+import java.util.List;
+
+public record LegacyStudyApplicationCommand(
+    List<String> friendStudentIds, List<Long> courseIds) {}

--- a/src/test/java/edu/handong/csee/histudy/architecture/LayerDependencyTest.java
+++ b/src/test/java/edu/handong/csee/histudy/architecture/LayerDependencyTest.java
@@ -26,7 +26,6 @@ class LayerDependencyTest {
           "BannerService.java: import edu.handong.csee.histudy.controller.form.BannerForm;",
           "BannerService.java: import edu.handong.csee.histudy.controller.form.BannerReorderForm;",
           "ReportService.java: import edu.handong.csee.histudy.controller.form.ReportForm;",
-          "UserService.java: import edu.handong.csee.histudy.controller.form.ApplyForm;",
           "UserService.java: import edu.handong.csee.histudy.controller.form.UserForm;");
   private static final List<String> FORBIDDEN_DEPENDENCY_PREFIXES =
       List.of(

--- a/src/test/java/edu/handong/csee/histudy/controller/ApplyFormControllerTest.java
+++ b/src/test/java/edu/handong/csee/histudy/controller/ApplyFormControllerTest.java
@@ -2,8 +2,10 @@ package edu.handong.csee.histudy.controller;
 
 import static edu.handong.csee.histudy.support.AuthClaimsFactory.memberClaims;
 import static edu.handong.csee.histudy.support.AuthClaimsFactory.userClaims;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -18,10 +20,12 @@ import edu.handong.csee.histudy.interceptor.AuthenticationInterceptor;
 import edu.handong.csee.histudy.service.DiscordService;
 import edu.handong.csee.histudy.service.JwtService;
 import edu.handong.csee.histudy.service.UserService;
+import edu.handong.csee.histudy.service.command.LegacyStudyApplicationCommand;
 import io.jsonwebtoken.Claims;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
@@ -56,15 +60,18 @@ class ApplyFormControllerTest {
   }
 
   @Test
-  void 사용자가_스터디신청시_성공_V1() throws Exception {
+  void 사용자가_V1으로_스터디를_신청하면_레거시명령과_인증이메일을_서비스에_전달한다() throws Exception {
+    // Given
     Claims claims = userClaims("user@test.com");
 
     ApplyForm form =
         ApplyForm.builder().friendIds(List.of("22500101")).courseIds(List.of(1L)).build();
 
     ApplyFormDto result = mock(ApplyFormDto.class);
-    when(userService.apply(any(ApplyForm.class), anyString())).thenReturn(result);
+    when(userService.apply(any(LegacyStudyApplicationCommand.class), anyString()))
+        .thenReturn(result);
 
+    // When
     mockMvc
         .perform(
             post("/api/forms")
@@ -73,6 +80,13 @@ class ApplyFormControllerTest {
                 .content(objectMapper.writeValueAsString(form)))
         .andExpect(status().isOk())
         .andExpect(content().contentType("application/json"));
+
+    // Then
+    ArgumentCaptor<LegacyStudyApplicationCommand> commandCaptor =
+        ArgumentCaptor.forClass(LegacyStudyApplicationCommand.class);
+    verify(userService).apply(commandCaptor.capture(), eq("user@test.com"));
+    assertThat(commandCaptor.getValue())
+        .isEqualTo(new LegacyStudyApplicationCommand(List.of("22500101"), List.of(1L)));
   }
 
   @Test

--- a/src/test/java/edu/handong/csee/histudy/service/UserServiceTest.java
+++ b/src/test/java/edu/handong/csee/histudy/service/UserServiceTest.java
@@ -3,7 +3,6 @@ package edu.handong.csee.histudy.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import edu.handong.csee.histudy.controller.form.ApplyForm;
 import edu.handong.csee.histudy.controller.form.UserForm;
 import edu.handong.csee.histudy.domain.AcademicTerm;
 import edu.handong.csee.histudy.domain.Course;
@@ -17,6 +16,7 @@ import edu.handong.csee.histudy.dto.ApplyFormDto;
 import edu.handong.csee.histudy.dto.UserDto;
 import edu.handong.csee.histudy.exception.NoCurrentTermFoundException;
 import edu.handong.csee.histudy.exception.UserAlreadyExistsException;
+import edu.handong.csee.histudy.service.command.LegacyStudyApplicationCommand;
 import edu.handong.csee.histudy.service.repository.fake.FakeAcademicTermRepository;
 import edu.handong.csee.histudy.service.repository.fake.FakeCourseRepository;
 import edu.handong.csee.histudy.service.repository.fake.FakeStudyApplicationRepository;
@@ -209,19 +209,15 @@ class UserServiceTest {
     User partner = userRepository.save(partnerUser);
     Course course = courseRepository.saveAll(List.of(primaryCourse)).get(0);
     userService.apply(
-        ApplyForm.builder()
-            .friendIds(List.of("22230001"))
-            .courseIds(List.of(course.getCourseId()))
-            .build(),
+        new LegacyStudyApplicationCommand(
+            List.of("22230001"), List.of(course.getCourseId())),
         "partner@histudy.com");
 
     // When
     ApplyFormDto result =
         userService.apply(
-            ApplyForm.builder()
-                .friendIds(List.of("22230002"))
-                .courseIds(List.of(course.getCourseId()))
-                .build(),
+            new LegacyStudyApplicationCommand(
+                List.of("22230002"), List.of(course.getCourseId())),
             "applicant@histudy.com");
 
     // Then
@@ -251,18 +247,14 @@ class UserServiceTest {
     Course firstCourse = courseRepository.saveAll(List.of(primaryCourse, secondaryCourse)).get(0);
     Course secondCourse = courseRepository.findAll().get(1);
     userService.apply(
-        ApplyForm.builder()
-            .friendIds(List.of("22230002"))
-            .courseIds(List.of(firstCourse.getCourseId()))
-            .build(),
+        new LegacyStudyApplicationCommand(
+            List.of("22230002"), List.of(firstCourse.getCourseId())),
         "applicant@histudy.com");
 
     // When
     userService.apply(
-        ApplyForm.builder()
-            .friendIds(List.of("22230003"))
-            .courseIds(List.of(secondCourse.getCourseId()))
-            .build(),
+        new LegacyStudyApplicationCommand(
+            List.of("22230003"), List.of(secondCourse.getCourseId())),
         "applicant@histudy.com");
 
     // Then
@@ -291,10 +283,8 @@ class UserServiceTest {
     assertThatThrownBy(
             () ->
                 userService.apply(
-                    ApplyForm.builder()
-                        .friendIds(List.of())
-                        .courseIds(List.of(course.getCourseId()))
-                        .build(),
+                    new LegacyStudyApplicationCommand(
+                        List.of(), List.of(course.getCourseId())),
                     "applicant@histudy.com"))
         .isInstanceOf(IllegalStateException.class);
   }
@@ -303,10 +293,11 @@ class UserServiceTest {
   void 현재_학기_없이_스터디를_신청하면_예외가_발생한다() {
     // Given
     userRepository.save(applicantUser);
-    ApplyForm form = ApplyForm.builder().friendIds(List.of()).courseIds(List.of()).build();
+    LegacyStudyApplicationCommand command =
+        new LegacyStudyApplicationCommand(List.of(), List.of());
 
     // When Then
-    assertThatThrownBy(() -> userService.apply(form, "applicant@histudy.com"))
+    assertThatThrownBy(() -> userService.apply(command, "applicant@histudy.com"))
         .isInstanceOf(NoCurrentTermFoundException.class);
   }
 

--- a/src/test/java/edu/handong/csee/histudy/service/command/LegacyStudyApplicationCommandTest.java
+++ b/src/test/java/edu/handong/csee/histudy/service/command/LegacyStudyApplicationCommandTest.java
@@ -1,0 +1,20 @@
+package edu.handong.csee.histudy.service.command;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class LegacyStudyApplicationCommandTest {
+
+  @Test
+  void 신청목록이_null이면_빈목록으로_변환한다() {
+    // Given
+
+    // When
+    LegacyStudyApplicationCommand command = new LegacyStudyApplicationCommand(null, null);
+
+    // Then
+    assertThat(command.friendStudentIds()).isEmpty();
+    assertThat(command.courseIds()).isEmpty();
+  }
+}


### PR DESCRIPTION
1. 레거시 스터디 신청 입력을 전용 명령으로 분리

> deprecated `/api/forms`는 친구를 문자열 학번으로 식별하고 v2는 숫자 사용자 ID를 사용합니다. 두 계약을 억지로 통합하지 않고 `LegacyStudyApplicationCommand`로 레거시 입력의 의미를 명확히 보존했습니다. 이에 따라 호환 API를 유지하면서도 HTTP form 자체는 서비스 경계를 넘지 않습니다.

2. `ApplyForm`을 컨트롤러 경계에서 명령으로 변환

> `ApplyFormController`가 친구 학번과 과목 ID를 명령으로 변환하고 인증 이메일은 별도 실행 문맥으로 전달하도록 변경했습니다. 기존 재신청, 상호 친구 요청 수락, 과목 선택 동작은 변경하지 않았습니다. 컨트롤러와 서비스 테스트에서 레거시 식별자와 v2 식별자 흐름이 분리된 채 유지되는지 검증했습니다.

3. 누락된 신청 목록을 안전한 빈 목록으로 정규화

> API 스키마에서 필수로 선언되지 않은 친구·과목 배열이 생략돼도 명령 생성 시 빈 목록으로 처리합니다. 전달된 목록은 불변 복사해 컨트롤러 이후의 변경이 서비스 실행에 영향을 주지 않도록 했습니다. 리뷰 지적을 회귀 테스트로 재현한 뒤 반영했습니다.

4. 서비스의 컨트롤러 의존 기준선 축소

> 아키텍처 테스트의 레거시 허용 목록에서 `UserService -> ApplyForm` 의존을 제거했습니다. 이후 신청 서비스가 컨트롤러 form을 다시 참조하면 테스트가 실패합니다. `./gradlew test --rerun-tasks` 전체 테스트와 `git show --check`를 통과해 API 호환성과 변경 형식을 확인했습니다.
