### PR TITLE
리포트 서비스의 HTTP 요청 객체 의존 제거

### DIFF
--- a/src/main/java/edu/handong/csee/histudy/controller/TeamController.java
+++ b/src/main/java/edu/handong/csee/histudy/controller/TeamController.java
@@ -10,6 +10,7 @@ import edu.handong.csee.histudy.service.CourseService;
 import edu.handong.csee.histudy.service.ImageService;
 import edu.handong.csee.histudy.service.ReportService;
 import edu.handong.csee.histudy.service.TeamService;
+import edu.handong.csee.histudy.service.command.ReportCommand;
 import io.jsonwebtoken.Claims;
 import java.util.List;
 import java.util.Map;
@@ -33,7 +34,7 @@ public class TeamController {
   public ReportDto.ReportInfo createReport(
       @RequestBody ReportForm form, @RequestAttribute Claims claims) {
     if (Role.isAuthorized(claims, Role.MEMBER)) {
-      return reportService.createReport(form, claims.getSubject());
+      return reportService.createReport(toReportCommand(form), claims.getSubject());
     }
     throw new ForbiddenException();
   }
@@ -61,7 +62,7 @@ public class TeamController {
   public ResponseEntity<String> updateReport(
       @PathVariable Long reportId, @RequestBody ReportForm form, @RequestAttribute Claims claims) {
     if (Role.isAuthorized(claims, Role.MEMBER)) {
-      return (reportService.updateReport(reportId, form))
+      return (reportService.updateReport(reportId, toReportCommand(form)))
           ? ResponseEntity.ok().build()
           : ResponseEntity.notFound().build();
     }
@@ -119,5 +120,15 @@ public class TeamController {
       return ResponseEntity.ok(response);
     }
     throw new ForbiddenException();
+  }
+
+  private ReportCommand toReportCommand(ReportForm form) {
+    return new ReportCommand(
+        form.getTitle(),
+        form.getContent(),
+        form.getTotalMinutes(),
+        form.getParticipants(),
+        form.getImages(),
+        form.getCourses());
   }
 }

--- a/src/main/java/edu/handong/csee/histudy/service/ReportService.java
+++ b/src/main/java/edu/handong/csee/histudy/service/ReportService.java
@@ -1,12 +1,12 @@
 package edu.handong.csee.histudy.service;
 
-import edu.handong.csee.histudy.controller.form.ReportForm;
 import edu.handong.csee.histudy.domain.*;
 import edu.handong.csee.histudy.dto.ReportDto;
 import edu.handong.csee.histudy.exception.NoCurrentTermFoundException;
 import edu.handong.csee.histudy.exception.ReportNotFoundException;
 import edu.handong.csee.histudy.exception.UserNotFoundException;
 import edu.handong.csee.histudy.repository.*;
+import edu.handong.csee.histudy.service.command.ReportCommand;
 import edu.handong.csee.histudy.util.ImagePathMapper;
 import java.util.List;
 import java.util.Map;
@@ -27,21 +27,21 @@ public class ReportService {
 
   private final ImagePathMapper imagePathMapper;
 
-  public ReportDto.ReportInfo createReport(ReportForm form, String email) {
+  public ReportDto.ReportInfo createReport(ReportCommand command, String email) {
     User user = userRepository.findUserByEmail(email).orElseThrow(UserNotFoundException::new);
     AcademicTerm currentTerm =
         academicTermRepository.findCurrentSemester().orElseThrow(NoCurrentTermFoundException::new);
     StudyGroup studyGroup = studyGroupRepository.findByUserAndTerm(user, currentTerm).orElseThrow();
 
     List<User> participants =
-        form.getParticipants().stream()
+        command.participantIds().stream()
             .map(userRepository::findById)
             .filter(Optional::isPresent)
             .map(Optional::get)
             .toList();
 
     List<Course> courses =
-        form.getCourses().stream()
+        command.courseIds().stream()
             .map(courseRepository::findById)
             .filter(Optional::isPresent)
             .map(Optional::get)
@@ -49,13 +49,13 @@ public class ReportService {
 
     // parse image path to filename
     // /path/to/image.png -> image.png
-    List<String> imageFilenames = imagePathMapper.extractFilename(form.getImages());
+    List<String> imageFilenames = imagePathMapper.extractFilename(command.imageUrls());
 
     StudyReport report =
         StudyReport.builder()
-            .title(form.getTitle())
-            .content(form.getContent())
-            .totalMinutes(form.getTotalMinutes())
+            .title(command.title())
+            .content(command.content())
+            .totalMinutes(command.totalMinutes())
             .studyGroup(studyGroup)
             .participants(participants)
             .images(imageFilenames)
@@ -85,16 +85,16 @@ public class ReportService {
         .toList();
   }
 
-  public boolean updateReport(Long reportId, ReportForm form) {
+  public boolean updateReport(Long reportId, ReportCommand command) {
     List<User> participants =
-        form.getParticipants().stream()
+        command.participantIds().stream()
             .map(userRepository::findById)
             .filter(Optional::isPresent)
             .map(Optional::get)
             .toList();
 
     List<Course> courses =
-        form.getCourses().stream()
+        command.courseIds().stream()
             .map(courseRepository::findById)
             .filter(Optional::isPresent)
             .map(Optional::get)
@@ -105,11 +105,11 @@ public class ReportService {
 
     // parse image path to filename
     // /path/to/image.png -> image.png
-    List<String> imageFilenames = imagePathMapper.extractFilename(form.getImages());
+    List<String> imageFilenames = imagePathMapper.extractFilename(command.imageUrls());
     targetReport.update(
-        form.getTitle(),
-        form.getContent(),
-        form.getTotalMinutes(),
+        command.title(),
+        command.content(),
+        command.totalMinutes(),
         imageFilenames,
         participants,
         courses);

--- a/src/main/java/edu/handong/csee/histudy/service/ReportService.java
+++ b/src/main/java/edu/handong/csee/histudy/service/ReportService.java
@@ -36,15 +36,13 @@ public class ReportService {
     List<User> participants =
         command.participantIds().stream()
             .map(userRepository::findById)
-            .filter(Optional::isPresent)
-            .map(Optional::get)
+            .flatMap(Optional::stream)
             .toList();
 
     List<Course> courses =
         command.courseIds().stream()
             .map(courseRepository::findById)
-            .filter(Optional::isPresent)
-            .map(Optional::get)
+            .flatMap(Optional::stream)
             .toList();
 
     // parse image path to filename
@@ -89,15 +87,13 @@ public class ReportService {
     List<User> participants =
         command.participantIds().stream()
             .map(userRepository::findById)
-            .filter(Optional::isPresent)
-            .map(Optional::get)
+            .flatMap(Optional::stream)
             .toList();
 
     List<Course> courses =
         command.courseIds().stream()
             .map(courseRepository::findById)
-            .filter(Optional::isPresent)
-            .map(Optional::get)
+            .flatMap(Optional::stream)
             .toList();
 
     StudyReport targetReport =

--- a/src/main/java/edu/handong/csee/histudy/service/command/ReportCommand.java
+++ b/src/main/java/edu/handong/csee/histudy/service/command/ReportCommand.java
@@ -8,4 +8,11 @@ public record ReportCommand(
     Long totalMinutes,
     List<Long> participantIds,
     List<String> imageUrls,
-    List<Long> courseIds) {}
+    List<Long> courseIds) {
+
+  public ReportCommand {
+    participantIds = participantIds == null ? List.of() : List.copyOf(participantIds);
+    imageUrls = imageUrls == null ? List.of() : List.copyOf(imageUrls);
+    courseIds = courseIds == null ? List.of() : List.copyOf(courseIds);
+  }
+}

--- a/src/main/java/edu/handong/csee/histudy/service/command/ReportCommand.java
+++ b/src/main/java/edu/handong/csee/histudy/service/command/ReportCommand.java
@@ -1,0 +1,11 @@
+package edu.handong.csee.histudy.service.command;
+
+import java.util.List;
+
+public record ReportCommand(
+    String title,
+    String content,
+    Long totalMinutes,
+    List<Long> participantIds,
+    List<String> imageUrls,
+    List<Long> courseIds) {}

--- a/src/test/java/edu/handong/csee/histudy/architecture/LayerDependencyTest.java
+++ b/src/test/java/edu/handong/csee/histudy/architecture/LayerDependencyTest.java
@@ -25,7 +25,6 @@ class LayerDependencyTest {
       List.of(
           "BannerService.java: import edu.handong.csee.histudy.controller.form.BannerForm;",
           "BannerService.java: import edu.handong.csee.histudy.controller.form.BannerReorderForm;",
-          "ReportService.java: import edu.handong.csee.histudy.controller.form.ReportForm;",
           "UserService.java: import edu.handong.csee.histudy.controller.form.ApplyForm;",
           "UserService.java: import edu.handong.csee.histudy.controller.form.UserForm;");
   private static final List<String> FORBIDDEN_DEPENDENCY_PREFIXES =

--- a/src/test/java/edu/handong/csee/histudy/controller/TeamControllerTest.java
+++ b/src/test/java/edu/handong/csee/histudy/controller/TeamControllerTest.java
@@ -2,6 +2,7 @@ package edu.handong.csee.histudy.controller;
 
 import static edu.handong.csee.histudy.support.AuthClaimsFactory.memberClaims;
 import static edu.handong.csee.histudy.support.AuthClaimsFactory.userClaims;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -19,11 +20,13 @@ import edu.handong.csee.histudy.service.ImageService;
 import edu.handong.csee.histudy.service.JwtService;
 import edu.handong.csee.histudy.service.ReportService;
 import edu.handong.csee.histudy.service.TeamService;
+import edu.handong.csee.histudy.service.command.ReportCommand;
 import io.jsonwebtoken.Claims;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
@@ -72,19 +75,23 @@ class TeamControllerTest {
 
   @Test
   void 그룹원이_스터디보고서생성시_성공() throws Exception {
+    // Given
     Claims claims = memberClaims("member@test.com");
 
     ReportForm form =
         ReportForm.builder()
+            .title("1주차")
             .courses(List.of(1L))
             .content("Study content")
             .totalMinutes(120L)
+            .participants(List.of(2L))
             .images(List.of("/path/to/image.jpg"))
             .build();
 
     ReportDto.ReportInfo reportInfo = mock(ReportDto.ReportInfo.class);
-    when(reportService.createReport(any(ReportForm.class), anyString())).thenReturn(reportInfo);
+    when(reportService.createReport(any(ReportCommand.class), anyString())).thenReturn(reportInfo);
 
+    // When
     mockMvc
         .perform(
             post("/api/team/reports")
@@ -93,6 +100,17 @@ class TeamControllerTest {
                 .content(objectMapper.writeValueAsString(form)))
         .andExpect(status().isOk())
         .andExpect(content().contentType("application/json"));
+
+    // Then
+    ArgumentCaptor<ReportCommand> commandCaptor = ArgumentCaptor.forClass(ReportCommand.class);
+    verify(reportService).createReport(commandCaptor.capture(), eq("member@test.com"));
+    ReportCommand command = commandCaptor.getValue();
+    assertThat(command.title()).isEqualTo("1주차");
+    assertThat(command.content()).isEqualTo("Study content");
+    assertThat(command.totalMinutes()).isEqualTo(120L);
+    assertThat(command.participantIds()).containsExactly(2L);
+    assertThat(command.imageUrls()).containsExactly("/path/to/image.jpg");
+    assertThat(command.courseIds()).containsExactly(1L);
   }
 
   @Test
@@ -134,18 +152,22 @@ class TeamControllerTest {
 
   @Test
   void 그룹원이_보고서수정시_성공() throws Exception {
+    // Given
     Claims claims = memberClaims("member@test.com");
 
     ReportForm form =
         ReportForm.builder()
+            .title("수정된 제목")
             .courses(List.of(1L))
             .content("Updated content")
             .totalMinutes(150L)
+            .participants(List.of(2L))
             .images(List.of("/path/to/updated_image.jpg"))
             .build();
 
-    when(reportService.updateReport(anyLong(), any(ReportForm.class))).thenReturn(true);
+    when(reportService.updateReport(anyLong(), any(ReportCommand.class))).thenReturn(true);
 
+    // When
     mockMvc
         .perform(
             patch("/api/team/reports/1")
@@ -153,6 +175,17 @@ class TeamControllerTest {
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .content(objectMapper.writeValueAsString(form)))
         .andExpect(status().isOk());
+
+    // Then
+    ArgumentCaptor<ReportCommand> commandCaptor = ArgumentCaptor.forClass(ReportCommand.class);
+    verify(reportService).updateReport(eq(1L), commandCaptor.capture());
+    ReportCommand command = commandCaptor.getValue();
+    assertThat(command.title()).isEqualTo("수정된 제목");
+    assertThat(command.content()).isEqualTo("Updated content");
+    assertThat(command.totalMinutes()).isEqualTo(150L);
+    assertThat(command.participantIds()).containsExactly(2L);
+    assertThat(command.imageUrls()).containsExactly("/path/to/updated_image.jpg");
+    assertThat(command.courseIds()).containsExactly(1L);
   }
 
   @Test
@@ -160,7 +193,7 @@ class TeamControllerTest {
     Claims claims = memberClaims("member@test.com");
 
     ReportForm form = ReportForm.builder().build();
-    when(reportService.updateReport(anyLong(), any(ReportForm.class))).thenReturn(false);
+    when(reportService.updateReport(anyLong(), any(ReportCommand.class))).thenReturn(false);
 
     mockMvc
         .perform(

--- a/src/test/java/edu/handong/csee/histudy/service/ReportServiceTest.java
+++ b/src/test/java/edu/handong/csee/histudy/service/ReportServiceTest.java
@@ -2,7 +2,6 @@ package edu.handong.csee.histudy.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import edu.handong.csee.histudy.controller.form.ReportForm;
 import edu.handong.csee.histudy.domain.AcademicTerm;
 import edu.handong.csee.histudy.domain.Course;
 import edu.handong.csee.histudy.domain.Role;
@@ -12,6 +11,7 @@ import edu.handong.csee.histudy.domain.StudyReport;
 import edu.handong.csee.histudy.domain.TermType;
 import edu.handong.csee.histudy.domain.User;
 import edu.handong.csee.histudy.dto.ReportDto;
+import edu.handong.csee.histudy.service.command.ReportCommand;
 import edu.handong.csee.histudy.service.repository.fake.FakeAcademicTermRepository;
 import edu.handong.csee.histudy.service.repository.fake.FakeCourseRepository;
 import edu.handong.csee.histudy.service.repository.fake.FakeStudyGroupRepository;
@@ -96,18 +96,17 @@ class ReportServiceTest {
     StudyApplicant applicant =
         StudyApplicant.of(currentTerm, savedMemberUser, List.of(), List.of(savedPrimaryCourse));
     studyGroupRepository.save(StudyGroup.of(1, currentTerm, List.of(applicant)));
-    ReportForm form =
-        ReportForm.builder()
-            .title("1주차")
-            .content("첫 모임")
-            .totalMinutes(90L)
-            .participants(List.of(savedParticipantUser.getUserId()))
-            .courses(List.of(savedPrimaryCourse.getCourseId()))
-            .images(List.of("https://histudy.handong.edu/images/reports/report1.png"))
-            .build();
+    ReportCommand command =
+        new ReportCommand(
+            "1주차",
+            "첫 모임",
+            90L,
+            List.of(savedParticipantUser.getUserId()),
+            List.of("https://histudy.handong.edu/images/reports/report1.png"),
+            List.of(savedPrimaryCourse.getCourseId()));
 
     // When
-    ReportDto.ReportInfo result = reportService.createReport(form, "member@histudy.com");
+    ReportDto.ReportInfo result = reportService.createReport(command, "member@histudy.com");
 
     // Then
     assertThat(studyReportRepository.findAll()).hasSize(1);
@@ -227,18 +226,17 @@ class ReportServiceTest {
                 .images(List.of("reports/one.png"))
                 .courses(List.of(savedPrimaryCourse))
                 .build());
-    ReportForm form =
-        ReportForm.builder()
-            .title("수정된 제목")
-            .content("수정된 내용")
-            .totalMinutes(120L)
-            .participants(List.of(savedMemberUser.getUserId()))
-            .courses(List.of(savedSecondaryCourse.getCourseId()))
-            .images(List.of("https://histudy.handong.edu/images/reports/two.png"))
-            .build();
+    ReportCommand command =
+        new ReportCommand(
+            "수정된 제목",
+            "수정된 내용",
+            120L,
+            List.of(savedMemberUser.getUserId()),
+            List.of("https://histudy.handong.edu/images/reports/two.png"),
+            List.of(savedSecondaryCourse.getCourseId()));
 
     // When
-    boolean updated = reportService.updateReport(savedReport.getStudyReportId(), form);
+    boolean updated = reportService.updateReport(savedReport.getStudyReportId(), command);
 
     // Then
     assertThat(updated).isTrue();

--- a/src/test/java/edu/handong/csee/histudy/service/command/ReportCommandTest.java
+++ b/src/test/java/edu/handong/csee/histudy/service/command/ReportCommandTest.java
@@ -1,0 +1,21 @@
+package edu.handong.csee.histudy.service.command;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class ReportCommandTest {
+
+  @Test
+  void 리포트목록이_null이면_빈목록으로_변환한다() {
+    // Given
+
+    // When
+    ReportCommand command = new ReportCommand("제목", "내용", 60L, null, null, null);
+
+    // Then
+    assertThat(command.participantIds()).isEmpty();
+    assertThat(command.imageUrls()).isEmpty();
+    assertThat(command.courseIds()).isEmpty();
+  }
+}


### PR DESCRIPTION
1. 리포트 생성·수정 입력을 `ReportCommand`로 분리

> 리포트 제목, 내용, 학습 시간, 참여자, 이미지, 과목은 하나의 유스케이스 입력으로 함께 변경됩니다. 이 값을 서비스 전용 명령으로 묶어 HTTP 바인딩 형식이 서비스 계약이 되지 않도록 했습니다. 별도 Port·Adapter·Mapper 계층은 만들지 않아 현재 레이어드 구조의 단순함은 유지했습니다.

2. `ReportForm`을 컨트롤러 경계에서 명령으로 변환

> `TeamController`가 HTTP 요청 객체를 해석하고 `ReportService`에는 필요한 값만 전달하도록 변경했습니다. 생성과 수정 요청의 JSON 및 응답 동작은 그대로 유지됩니다. 컨트롤러 테스트에서 여섯 입력 필드와 인증 이메일이 정확히 전달되는지 검증했습니다.

3. 선택 목록의 null 안전성과 조회 코드 가독성 보완

> API 스키마에서 필수로 선언되지 않은 참여자·이미지·과목 배열은 명령 생성 시 빈 목록으로 정규화하고 불변 복사합니다. 저장소 조회 결과의 `Optional` 처리는 `Optional::stream`으로 단순화해 누락 엔티티를 제외하는 기존 의미를 더 명확히 표현했습니다. 리뷰 지적을 회귀 테스트로 재현한 뒤 반영했습니다.

4. 서비스의 컨트롤러 의존 기준선 축소

> 아키텍처 테스트의 레거시 허용 목록에서 `ReportService -> ReportForm` 의존을 제거했습니다. 이후 리포트 서비스가 다시 컨트롤러 form을 참조하면 테스트가 실패합니다. `./gradlew test --rerun-tasks` 전체 테스트와 `git show --check`를 통과해 기존 동작과 변경 형식을 확인했습니다.
