### PR TITLE
사용자 서비스의 회원가입 요청 객체 의존 제거

### DIFF
--- a/src/main/java/edu/handong/csee/histudy/controller/UserController.java
+++ b/src/main/java/edu/handong/csee/histudy/controller/UserController.java
@@ -9,6 +9,7 @@ import edu.handong.csee.histudy.exception.ForbiddenException;
 import edu.handong.csee.histudy.jwt.JwtPair;
 import edu.handong.csee.histudy.service.JwtService;
 import edu.handong.csee.histudy.service.UserService;
+import edu.handong.csee.histudy.service.command.SignUpCommand;
 import io.jsonwebtoken.Claims;
 import java.util.Collections;
 import java.util.Comparator;
@@ -28,7 +29,9 @@ public class UserController {
 
   @PostMapping("/api/users")
   public ResponseEntity<UserDto.UserLogin> createUser(@RequestBody UserForm userForm) {
-    userService.signUp(userForm);
+    userService.signUp(
+        new SignUpCommand(
+            userForm.getSub(), userForm.getName(), userForm.getEmail(), userForm.getSid()));
     JwtPair tokens = jwtService.issueToken(userForm.getEmail(), userForm.getName(), Role.USER);
 
     return ResponseEntity.ok(

--- a/src/main/java/edu/handong/csee/histudy/controller/UserController.java
+++ b/src/main/java/edu/handong/csee/histudy/controller/UserController.java
@@ -29,10 +29,11 @@ public class UserController {
 
   @PostMapping("/api/users")
   public ResponseEntity<UserDto.UserLogin> createUser(@RequestBody UserForm userForm) {
-    userService.signUp(
+    SignUpCommand command =
         new SignUpCommand(
-            userForm.getSub(), userForm.getName(), userForm.getEmail(), userForm.getSid()));
-    JwtPair tokens = jwtService.issueToken(userForm.getEmail(), userForm.getName(), Role.USER);
+            userForm.getSub(), userForm.getName(), userForm.getEmail(), userForm.getSid());
+    userService.signUp(command);
+    JwtPair tokens = jwtService.issueToken(command.email(), command.name(), Role.USER);
 
     return ResponseEntity.ok(
         UserDto.UserLogin.builder()

--- a/src/main/java/edu/handong/csee/histudy/service/UserService.java
+++ b/src/main/java/edu/handong/csee/histudy/service/UserService.java
@@ -1,13 +1,13 @@
 package edu.handong.csee.histudy.service;
 
 import edu.handong.csee.histudy.controller.form.ApplyForm;
-import edu.handong.csee.histudy.controller.form.UserForm;
 import edu.handong.csee.histudy.domain.*;
 import edu.handong.csee.histudy.dto.ApplyFormDto;
 import edu.handong.csee.histudy.dto.UserDto;
 import edu.handong.csee.histudy.exception.*;
 import edu.handong.csee.histudy.repository.*;
 import edu.handong.csee.histudy.repository.StudyApplicantRepository;
+import edu.handong.csee.histudy.service.command.SignUpCommand;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -122,9 +122,9 @@ public class UserService {
             });
   }
 
-  public void signUp(UserForm userForm) {
+  public void signUp(SignUpCommand command) {
     userRepository
-        .findUserBySub(userForm.getSub())
+        .findUserBySub(command.sub())
         .ifPresentOrElse(
             __ -> {
               throw new UserAlreadyExistsException();
@@ -132,10 +132,10 @@ public class UserService {
             () ->
                 userRepository.save(
                     User.builder()
-                        .sid(userForm.getSid())
-                        .email(userForm.getEmail())
-                        .name(userForm.getName())
-                        .sub(userForm.getSub())
+                        .sid(command.sid())
+                        .email(command.email())
+                        .name(command.name())
+                        .sub(command.sub())
                         .role(Role.USER)
                         .build()));
   }

--- a/src/main/java/edu/handong/csee/histudy/service/command/SignUpCommand.java
+++ b/src/main/java/edu/handong/csee/histudy/service/command/SignUpCommand.java
@@ -1,0 +1,3 @@
+package edu.handong.csee.histudy.service.command;
+
+public record SignUpCommand(String sub, String name, String email, String sid) {}

--- a/src/test/java/edu/handong/csee/histudy/architecture/LayerDependencyTest.java
+++ b/src/test/java/edu/handong/csee/histudy/architecture/LayerDependencyTest.java
@@ -26,8 +26,7 @@ class LayerDependencyTest {
           "BannerService.java: import edu.handong.csee.histudy.controller.form.BannerForm;",
           "BannerService.java: import edu.handong.csee.histudy.controller.form.BannerReorderForm;",
           "ReportService.java: import edu.handong.csee.histudy.controller.form.ReportForm;",
-          "UserService.java: import edu.handong.csee.histudy.controller.form.ApplyForm;",
-          "UserService.java: import edu.handong.csee.histudy.controller.form.UserForm;");
+          "UserService.java: import edu.handong.csee.histudy.controller.form.ApplyForm;");
   private static final List<String> FORBIDDEN_DEPENDENCY_PREFIXES =
       List.of(
           "edu.handong.csee.histudy.controller.",

--- a/src/test/java/edu/handong/csee/histudy/controller/UserControllerTest.java
+++ b/src/test/java/edu/handong/csee/histudy/controller/UserControllerTest.java
@@ -16,6 +16,7 @@ import edu.handong.csee.histudy.jwt.JwtPair;
 import edu.handong.csee.histudy.service.DiscordService;
 import edu.handong.csee.histudy.service.JwtService;
 import edu.handong.csee.histudy.service.UserService;
+import edu.handong.csee.histudy.service.command.SignUpCommand;
 import io.jsonwebtoken.Claims;
 import java.util.List;
 import java.util.Optional;
@@ -56,13 +57,14 @@ class UserControllerTest {
   }
 
   @Test
-  void 사용자가_회원가입시_성공() throws Exception {
+  void 사용자가_회원가입하면_요청값을_서비스명령으로_전달하고_토큰을_발급한다() throws Exception {
+    // Given
     UserForm userForm = new UserForm("google-sub-123", "Test User", "user@test.com", "22500101");
     JwtPair tokens = new JwtPair(List.of("access-token", "refresh-token"));
 
-    doNothing().when(userService).signUp(any(UserForm.class));
-    when(jwtService.issueToken(anyString(), anyString(), any(Role.class))).thenReturn(tokens);
+    when(jwtService.issueToken("user@test.com", "Test User", Role.USER)).thenReturn(tokens);
 
+    // When
     mockMvc
         .perform(
             post("/api/users")
@@ -73,6 +75,11 @@ class UserControllerTest {
         .andExpect(jsonPath("$.isRegistered").value(true))
         .andExpect(jsonPath("$.tokenType").value("Bearer "))
         .andExpect(jsonPath("$.role").value("USER"));
+
+    // Then
+    verify(userService)
+        .signUp(new SignUpCommand("google-sub-123", "Test User", "user@test.com", "22500101"));
+    verify(jwtService).issueToken("user@test.com", "Test User", Role.USER);
   }
 
   @Test

--- a/src/test/java/edu/handong/csee/histudy/service/UserServiceTest.java
+++ b/src/test/java/edu/handong/csee/histudy/service/UserServiceTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import edu.handong.csee.histudy.controller.form.ApplyForm;
-import edu.handong.csee.histudy.controller.form.UserForm;
 import edu.handong.csee.histudy.domain.AcademicTerm;
 import edu.handong.csee.histudy.domain.Course;
 import edu.handong.csee.histudy.domain.RequestStatus;
@@ -17,6 +16,7 @@ import edu.handong.csee.histudy.dto.ApplyFormDto;
 import edu.handong.csee.histudy.dto.UserDto;
 import edu.handong.csee.histudy.exception.NoCurrentTermFoundException;
 import edu.handong.csee.histudy.exception.UserAlreadyExistsException;
+import edu.handong.csee.histudy.service.command.SignUpCommand;
 import edu.handong.csee.histudy.service.repository.fake.FakeAcademicTermRepository;
 import edu.handong.csee.histudy.service.repository.fake.FakeCourseRepository;
 import edu.handong.csee.histudy.service.repository.fake.FakeStudyApplicationRepository;
@@ -118,8 +118,8 @@ class UserServiceTest {
           .professor("Lee")
           .academicTerm(currentTerm)
           .build();
-  private final UserForm signUpForm =
-      new UserForm("sub-10", "Alice", "alice@histudy.com", "22230010");
+  private final SignUpCommand signUpCommand =
+      new SignUpCommand("sub-10", "Alice", "alice@histudy.com", "22230010");
 
   private FakeUserRepository userRepository;
   private FakeCourseRepository courseRepository;
@@ -173,14 +173,17 @@ class UserServiceTest {
   }
 
   @Test
-  void 회원가입하면_USER_권한으로_저장된다() {
+  void 회원가입하면_명령의_사용자정보를_USER_권한으로_저장한다() {
     // Given
     // When
-    userService.signUp(signUpForm);
+    userService.signUp(signUpCommand);
 
     // Then
     User savedUser = userRepository.findUserBySub("sub-10").orElseThrow();
+    assertThat(savedUser.getSub()).isEqualTo("sub-10");
+    assertThat(savedUser.getName()).isEqualTo("Alice");
     assertThat(savedUser.getEmail()).isEqualTo("alice@histudy.com");
+    assertThat(savedUser.getSid()).isEqualTo("22230010");
     assertThat(savedUser.getRole()).isEqualTo(Role.USER);
   }
 
@@ -197,7 +200,7 @@ class UserServiceTest {
             .build());
 
     // When Then
-    assertThatThrownBy(() -> userService.signUp(signUpForm))
+    assertThatThrownBy(() -> userService.signUp(signUpCommand))
         .isInstanceOf(UserAlreadyExistsException.class);
   }
 


### PR DESCRIPTION
1. 회원가입 입력을 `SignUpCommand`로 분리

> 사용자 식별자, 이름, 이메일, 학번은 회원가입 유스케이스를 구성하는 하나의 입력 집합입니다. 서비스 전용 명령으로 표현해 HTTP 요청 객체의 변경이 서비스 계층까지 전파되지 않도록 했습니다. 단순한 입력 경계 분리에 집중하고 도메인 및 영속성 모델은 변경하지 않았습니다.

2. `UserForm`을 컨트롤러 경계에서 명령으로 변환

> `UserController`가 회원가입 form을 명령으로 한 번 변환한 뒤 `UserService`를 호출하도록 변경했습니다. JWT도 같은 명령의 이메일과 이름으로 발급하므로 변환 이후 입력 기준이 하나로 유지되며 기존 응답과 인증 흐름은 보존됩니다. 컨트롤러 테스트에서 명령의 네 필드와 토큰 발급 인자를 정확히 검증했습니다.

3. 서비스의 컨트롤러 의존 기준선 축소

> 아키텍처 테스트의 레거시 허용 목록에서 `UserService -> UserForm` 의존을 제거했습니다. 이후 회원가입 서비스가 HTTP form을 다시 직접 참조하면 경계 테스트가 실패합니다. `./gradlew test --rerun-tasks` 전체 테스트와 `git show --check`를 통과해 중복 가입 예외와 기존 API 동작을 함께 확인했습니다.
