### PR TITLE
배너 재정렬 서비스의 HTTP 요청 객체 의존 제거

### DIFF
--- a/src/main/java/edu/handong/csee/histudy/controller/BannerAdminController.java
+++ b/src/main/java/edu/handong/csee/histudy/controller/BannerAdminController.java
@@ -49,7 +49,7 @@ public class BannerAdminController {
   public ResponseEntity<Void> reorderBanners(
       @RequestBody BannerReorderForm form, @RequestAttribute Claims claims) {
     requireAdmin(claims);
-    bannerService.reorderBanners(form);
+    bannerService.reorderBanners(form.getOrderedIds());
     return ResponseEntity.ok().build();
   }
 

--- a/src/main/java/edu/handong/csee/histudy/service/BannerService.java
+++ b/src/main/java/edu/handong/csee/histudy/service/BannerService.java
@@ -4,7 +4,6 @@ import static edu.handong.csee.histudy.util.ImageDirectories.BANNER;
 import static org.springframework.util.ResourceUtils.isUrl;
 
 import edu.handong.csee.histudy.controller.form.BannerForm;
-import edu.handong.csee.histudy.controller.form.BannerReorderForm;
 import edu.handong.csee.histudy.domain.Banner;
 import edu.handong.csee.histudy.dto.BannerDto;
 import edu.handong.csee.histudy.exception.BannerNotFoundException;
@@ -24,7 +23,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -127,9 +125,8 @@ public class BannerService {
     normalizeDisplayOrder();
   }
 
-  public void reorderBanners(BannerReorderForm form) {
-    validateFormIsNotNull(form);
-    List<Long> orderedIds = Optional.ofNullable(form.getOrderedIds()).orElse(List.of());
+  public void reorderBanners(List<Long> requestedOrder) {
+    List<Long> orderedIds = requestedOrder == null ? List.of() : requestedOrder;
     List<Banner> banners = bannerRepository.findAllByOrderByDisplayOrderAsc();
 
     if (banners.isEmpty()) {

--- a/src/test/java/edu/handong/csee/histudy/architecture/LayerDependencyTest.java
+++ b/src/test/java/edu/handong/csee/histudy/architecture/LayerDependencyTest.java
@@ -23,8 +23,7 @@ class LayerDependencyTest {
       "edu.handong.csee.histudy.repository.";
   private static final List<String> LEGACY_SERVICE_CONTROLLER_DEPENDENCIES =
       List.of(
-          "BannerService.java: import edu.handong.csee.histudy.controller.form.BannerForm;",
-          "BannerService.java: import edu.handong.csee.histudy.controller.form.BannerReorderForm;");
+          "BannerService.java: import edu.handong.csee.histudy.controller.form.BannerForm;");
   private static final List<String> FORBIDDEN_DEPENDENCY_PREFIXES =
       List.of(
           "edu.handong.csee.histudy.controller.",

--- a/src/test/java/edu/handong/csee/histudy/controller/BannerAdminControllerTest.java
+++ b/src/test/java/edu/handong/csee/histudy/controller/BannerAdminControllerTest.java
@@ -114,7 +114,7 @@ class BannerAdminControllerTest {
                 .content(objectMapper.writeValueAsString(form)))
         .andExpect(status().isOk());
 
-    verify(bannerService).reorderBanners(any(BannerReorderForm.class));
+    verify(bannerService).reorderBanners(List.of(2L, 1L));
   }
 
   @Test

--- a/src/test/java/edu/handong/csee/histudy/service/BannerServiceTest.java
+++ b/src/test/java/edu/handong/csee/histudy/service/BannerServiceTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import edu.handong.csee.histudy.controller.form.BannerForm;
-import edu.handong.csee.histudy.controller.form.BannerReorderForm;
 import edu.handong.csee.histudy.domain.Banner;
 import edu.handong.csee.histudy.dto.BannerDto;
 import edu.handong.csee.histudy.exception.BannerNotFoundException;
@@ -184,8 +183,7 @@ class BannerServiceTest {
     Banner second = bannerRepository.save(secondBanner);
 
     // When
-    bannerService.reorderBanners(
-        new BannerReorderForm(List.of(second.getBannerId(), first.getBannerId())));
+    bannerService.reorderBanners(List.of(second.getBannerId(), first.getBannerId()));
 
     // Then
     assertThat(bannerRepository.findAllByOrderByDisplayOrderAsc())
@@ -204,8 +202,7 @@ class BannerServiceTest {
     // When Then
     assertThatThrownBy(
             () ->
-                bannerService.reorderBanners(
-                    new BannerReorderForm(List.of(first.getBannerId(), 999L))))
+                bannerService.reorderBanners(List.of(first.getBannerId(), 999L)))
         .isInstanceOf(MissingParameterException.class);
   }
 


### PR DESCRIPTION
1. 배너 재정렬 서비스 입력을 순서 목록으로 단순화

> 배너 재정렬은 정렬된 ID 목록 하나만 필요한 단순 유스케이스입니다. 별도 command를 추가하지 않고 `List<Long>`을 서비스 입력으로 사용해 타입 증가 없이 HTTP 요청 객체 의존을 제거했습니다. 기존의 전체 ID 포함, 중복, 유효하지 않은 ID 검증은 그대로 유지됩니다.

2. `BannerReorderForm`을 컨트롤러 경계에서 해체

> `BannerAdminController`가 JSON 요청 form에서 `orderedIds`를 꺼내 서비스에 전달하도록 변경했습니다. HTTP 요청 및 응답 계약은 바뀌지 않습니다. 컨트롤러 테스트에서 요청 목록이 서비스에 정확히 전달되는지 검증했습니다.

3. 서비스의 컨트롤러 의존 기준선 축소

> 아키텍처 테스트의 레거시 허용 목록에서 `BannerService -> BannerReorderForm` 의존을 제거했습니다. 이후 배너 재정렬 서비스가 HTTP form을 다시 참조하면 경계 테스트가 실패합니다. `./gradlew test --rerun-tasks` 전체 테스트와 `git diff --check`를 통과해 기존 배너 동작을 확인했습니다.
