### PR TITLE
배너 서비스의 HTTP 요청 객체 의존 제거

### DIFF
--- a/src/main/java/edu/handong/csee/histudy/controller/BannerAdminController.java
+++ b/src/main/java/edu/handong/csee/histudy/controller/BannerAdminController.java
@@ -6,6 +6,7 @@ import edu.handong.csee.histudy.domain.Role;
 import edu.handong.csee.histudy.dto.BannerDto;
 import edu.handong.csee.histudy.exception.FileTransferException;
 import edu.handong.csee.histudy.exception.ForbiddenException;
+import edu.handong.csee.histudy.exception.MissingParameterException;
 import edu.handong.csee.histudy.service.BannerService;
 import edu.handong.csee.histudy.service.command.BannerCommand;
 import edu.handong.csee.histudy.service.command.BannerImage;
@@ -23,6 +24,8 @@ import org.springframework.web.multipart.MultipartFile;
 @RequiredArgsConstructor
 @RequestMapping("/api/admin/banners")
 public class BannerAdminController {
+
+  private static final String MESSAGE_MAX_FILE_SIZE = "이미지 파일 크기는 5MB 이하여야 합니다.";
 
   private final BannerService bannerService;
 
@@ -81,8 +84,11 @@ public class BannerAdminController {
   }
 
   private BannerImage toBannerImage(MultipartFile image) {
-    if (image == null) {
+    if (image == null || image.isEmpty()) {
       return null;
+    }
+    if (image.getSize() > BannerImage.MAX_SIZE_BYTES) {
+      throw new MissingParameterException(MESSAGE_MAX_FILE_SIZE);
     }
 
     try {

--- a/src/main/java/edu/handong/csee/histudy/controller/BannerAdminController.java
+++ b/src/main/java/edu/handong/csee/histudy/controller/BannerAdminController.java
@@ -4,15 +4,20 @@ import edu.handong.csee.histudy.controller.form.BannerForm;
 import edu.handong.csee.histudy.controller.form.BannerReorderForm;
 import edu.handong.csee.histudy.domain.Role;
 import edu.handong.csee.histudy.dto.BannerDto;
+import edu.handong.csee.histudy.exception.FileTransferException;
 import edu.handong.csee.histudy.exception.ForbiddenException;
 import edu.handong.csee.histudy.service.BannerService;
+import edu.handong.csee.histudy.service.command.BannerCommand;
+import edu.handong.csee.histudy.service.command.BannerImage;
 import io.jsonwebtoken.Claims;
+import java.io.IOException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
@@ -31,7 +36,7 @@ public class BannerAdminController {
   public ResponseEntity<BannerDto.AdminBannerInfo> createBanner(
       @ModelAttribute BannerForm form, @RequestAttribute Claims claims) {
     requireAdmin(claims);
-    BannerDto.AdminBannerInfo created = bannerService.createBanner(form);
+    BannerDto.AdminBannerInfo created = bannerService.createBanner(toBannerCommand(form));
     return ResponseEntity.status(HttpStatus.CREATED).body(created);
   }
 
@@ -41,7 +46,7 @@ public class BannerAdminController {
       @ModelAttribute BannerForm form,
       @RequestAttribute Claims claims) {
     requireAdmin(claims);
-    BannerDto.AdminBannerInfo updated = bannerService.updateBanner(bannerId, form);
+    BannerDto.AdminBannerInfo updated = bannerService.updateBanner(bannerId, toBannerCommand(form));
     return ResponseEntity.ok(updated);
   }
 
@@ -64,6 +69,27 @@ public class BannerAdminController {
   private void requireAdmin(Claims claims) {
     if (!Role.isAuthorized(claims, Role.ADMIN)) {
       throw new ForbiddenException();
+    }
+  }
+
+  private BannerCommand toBannerCommand(BannerForm form) {
+    return new BannerCommand(
+        form.getLabel(),
+        form.getRedirectUrl(),
+        form.getActive(),
+        toBannerImage(form.getImage()));
+  }
+
+  private BannerImage toBannerImage(MultipartFile image) {
+    if (image == null) {
+      return null;
+    }
+
+    try {
+      return new BannerImage(
+          image.getOriginalFilename(), image.getContentType(), image.getBytes());
+    } catch (IOException e) {
+      throw new FileTransferException();
     }
   }
 }

--- a/src/main/java/edu/handong/csee/histudy/service/BannerService.java
+++ b/src/main/java/edu/handong/csee/histudy/service/BannerService.java
@@ -40,7 +40,6 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 @RequiredArgsConstructor
 public class BannerService {
 
-  private static final long MAX_IMAGE_SIZE_BYTES = 5L * 1024 * 1024;
   private static final String IMAGE_NAME_FALLBACK_LABEL = "image";
   private static final String MESSAGE_MISSING_IMAGE = "이미지 파일은 필수입니다.";
   private static final String MESSAGE_MISSING_LABEL = "label은(는) 필수입니다.";
@@ -176,7 +175,7 @@ public class BannerService {
   }
 
   private void validateImage(BannerImage image) {
-    if (image.size() > MAX_IMAGE_SIZE_BYTES) {
+    if (image.size() > BannerImage.MAX_SIZE_BYTES) {
       throw new MissingParameterException(MESSAGE_MAX_FILE_SIZE);
     }
 

--- a/src/main/java/edu/handong/csee/histudy/service/BannerService.java
+++ b/src/main/java/edu/handong/csee/histudy/service/BannerService.java
@@ -3,13 +3,14 @@ package edu.handong.csee.histudy.service;
 import static edu.handong.csee.histudy.util.ImageDirectories.BANNER;
 import static org.springframework.util.ResourceUtils.isUrl;
 
-import edu.handong.csee.histudy.controller.form.BannerForm;
 import edu.handong.csee.histudy.domain.Banner;
 import edu.handong.csee.histudy.dto.BannerDto;
 import edu.handong.csee.histudy.exception.BannerNotFoundException;
 import edu.handong.csee.histudy.exception.FileTransferException;
 import edu.handong.csee.histudy.exception.MissingParameterException;
 import edu.handong.csee.histudy.repository.BannerRepository;
+import edu.handong.csee.histudy.service.command.BannerCommand;
+import edu.handong.csee.histudy.service.command.BannerImage;
 import edu.handong.csee.histudy.util.ImagePathMapper;
 import edu.handong.csee.histudy.util.Utils;
 import java.awt.image.BufferedImage;
@@ -33,7 +34,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
-import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @Transactional
@@ -76,13 +76,13 @@ public class BannerService {
         .toList();
   }
 
-  public BannerDto.AdminBannerInfo createBanner(BannerForm form) {
-    validateFormIsNotNull(form);
-    validateCreateForm(form);
-    MultipartFile image = form.getImage();
+  public BannerDto.AdminBannerInfo createBanner(BannerCommand command) {
+    validateRequestIsNotNull(command);
+    validateCreateCommand(command);
+    BannerImage image = command.image();
     validateImage(image);
 
-    String imagePath = saveImage(image, form.getLabel());
+    String imagePath = saveImage(image, command.label());
     scheduleImageDeletionAfterRollback(imagePath);
     int nextOrder =
         bannerRepository.findTopByOrderByDisplayOrderDesc().map(Banner::getDisplayOrder).orElse(0)
@@ -90,10 +90,10 @@ public class BannerService {
 
     Banner banner =
         Banner.builder()
-            .label(form.getLabel().trim())
+            .label(command.label().trim())
             .imagePath(imagePath)
-            .redirectUrl(normalizeRedirectUrl(form.getRedirectUrl()))
-            .active(form.getActive() == null || form.getActive())
+            .redirectUrl(normalizeRedirectUrl(command.redirectUrl()))
+            .active(command.active() == null || command.active())
             .displayOrder(nextOrder)
             .build();
 
@@ -101,15 +101,15 @@ public class BannerService {
     return toAdminBannerInfo(saved);
   }
 
-  public BannerDto.AdminBannerInfo updateBanner(Long bannerId, BannerForm form) {
-    validateFormIsNotNull(form);
+  public BannerDto.AdminBannerInfo updateBanner(Long bannerId, BannerCommand command) {
+    validateRequestIsNotNull(command);
     Banner banner = findBanner(bannerId);
 
     boolean hasAnyUpdate = false;
-    hasAnyUpdate |= updateLabelIfPresent(banner, form.getLabel());
-    hasAnyUpdate |= updateRedirectUrlIfPresent(banner, form.getRedirectUrl());
-    hasAnyUpdate |= updateActiveIfPresent(banner, form.getActive());
-    hasAnyUpdate |= updateImageIfPresent(banner, form.getImage());
+    hasAnyUpdate |= updateLabelIfPresent(banner, command.label());
+    hasAnyUpdate |= updateRedirectUrlIfPresent(banner, command.redirectUrl());
+    hasAnyUpdate |= updateActiveIfPresent(banner, command.active());
+    hasAnyUpdate |= updateImageIfPresent(banner, command.image());
 
     if (!hasAnyUpdate) {
       throw new MissingParameterException(MESSAGE_MISSING_UPDATE_PAYLOAD);
@@ -162,11 +162,11 @@ public class BannerService {
     bannerRepository.saveAll(banners);
   }
 
-  private void validateCreateForm(BannerForm form) {
-    if (form.getImage() == null || form.getImage().isEmpty()) {
+  private void validateCreateCommand(BannerCommand command) {
+    if (command.image() == null || command.image().isEmpty()) {
       throw new MissingParameterException(MESSAGE_MISSING_IMAGE);
     }
-    validateBlankField(form.getLabel(), MESSAGE_MISSING_LABEL);
+    validateBlankField(command.label(), MESSAGE_MISSING_LABEL);
   }
 
   private void validateBlankField(String field, String message) {
@@ -175,17 +175,17 @@ public class BannerService {
     }
   }
 
-  private void validateImage(MultipartFile image) {
-    if (image.getSize() > MAX_IMAGE_SIZE_BYTES) {
+  private void validateImage(BannerImage image) {
+    if (image.size() > MAX_IMAGE_SIZE_BYTES) {
       throw new MissingParameterException(MESSAGE_MAX_FILE_SIZE);
     }
 
-    String contentType = image.getContentType();
+    String contentType = image.contentType();
     if (contentType == null || !contentType.startsWith("image/")) {
       throw new MissingParameterException(MESSAGE_IMAGE_ONLY);
     }
 
-    try (var inputStream = image.getInputStream()) {
+    try (var inputStream = image.inputStream()) {
       BufferedImage decodedImage = ImageIO.read(inputStream);
       if (decodedImage == null) {
         throw new MissingParameterException(MESSAGE_IMAGE_ONLY);
@@ -241,8 +241,8 @@ public class BannerService {
     return normalized;
   }
 
-  private String saveImage(MultipartFile image, String label) {
-    String extension = getExtension(image.getOriginalFilename());
+  private String saveImage(BannerImage image, String label) {
+    String extension = getExtension(image.originalFilename());
     String normalizedLabel = normalizeLabelForFilename(label);
     String dateTime = Utils.getCurrentFormattedDateTime("yyyyMMdd_HHmmss");
     String random = UUID.randomUUID().toString().replace("-", "").substring(0, 12);
@@ -257,7 +257,7 @@ public class BannerService {
     }
 
     try {
-      image.transferTo(file);
+      Files.write(file.toPath(), image.content());
       return relativePath;
     } catch (IOException e) {
       throw new FileTransferException();
@@ -296,8 +296,8 @@ public class BannerService {
     }
   }
 
-  private void validateFormIsNotNull(Object form) {
-    if (form == null) {
+  private void validateRequestIsNotNull(Object request) {
+    if (request == null) {
       throw new MissingParameterException(MESSAGE_EMPTY_REQUEST_BODY);
     }
   }
@@ -327,7 +327,7 @@ public class BannerService {
     return true;
   }
 
-  private boolean updateImageIfPresent(Banner banner, MultipartFile image) {
+  private boolean updateImageIfPresent(Banner banner, BannerImage image) {
     if (image == null || image.isEmpty()) {
       return false;
     }

--- a/src/main/java/edu/handong/csee/histudy/service/command/BannerCommand.java
+++ b/src/main/java/edu/handong/csee/histudy/service/command/BannerCommand.java
@@ -1,0 +1,4 @@
+package edu.handong.csee.histudy.service.command;
+
+public record BannerCommand(
+    String label, String redirectUrl, Boolean active, BannerImage image) {}

--- a/src/main/java/edu/handong/csee/histudy/service/command/BannerImage.java
+++ b/src/main/java/edu/handong/csee/histudy/service/command/BannerImage.java
@@ -5,6 +5,8 @@ import java.io.InputStream;
 
 public record BannerImage(String originalFilename, String contentType, byte[] content) {
 
+  public static final long MAX_SIZE_BYTES = 5L * 1024 * 1024;
+
   public BannerImage {
     content = content == null ? new byte[0] : content.clone();
   }

--- a/src/main/java/edu/handong/csee/histudy/service/command/BannerImage.java
+++ b/src/main/java/edu/handong/csee/histudy/service/command/BannerImage.java
@@ -1,0 +1,28 @@
+package edu.handong.csee.histudy.service.command;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+public record BannerImage(String originalFilename, String contentType, byte[] content) {
+
+  public BannerImage {
+    content = content == null ? new byte[0] : content.clone();
+  }
+
+  @Override
+  public byte[] content() {
+    return content.clone();
+  }
+
+  public long size() {
+    return content.length;
+  }
+
+  public boolean isEmpty() {
+    return content.length == 0;
+  }
+
+  public InputStream inputStream() {
+    return new ByteArrayInputStream(content);
+  }
+}

--- a/src/test/java/edu/handong/csee/histudy/architecture/LayerDependencyTest.java
+++ b/src/test/java/edu/handong/csee/histudy/architecture/LayerDependencyTest.java
@@ -21,9 +21,7 @@ class LayerDependencyTest {
       "edu.handong.csee.histudy.controller.";
   private static final String REPOSITORY_PACKAGE_PREFIX =
       "edu.handong.csee.histudy.repository.";
-  private static final List<String> LEGACY_SERVICE_CONTROLLER_DEPENDENCIES =
-      List.of(
-          "BannerService.java: import edu.handong.csee.histudy.controller.form.BannerForm;");
+  private static final List<String> LEGACY_SERVICE_CONTROLLER_DEPENDENCIES = List.of();
   private static final List<String> FORBIDDEN_DEPENDENCY_PREFIXES =
       List.of(
           "edu.handong.csee.histudy.controller.",

--- a/src/test/java/edu/handong/csee/histudy/controller/BannerAdminControllerTest.java
+++ b/src/test/java/edu/handong/csee/histudy/controller/BannerAdminControllerTest.java
@@ -4,6 +4,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.handong.csee.histudy.controller.form.BannerReorderForm;
@@ -14,10 +15,12 @@ import edu.handong.csee.histudy.interceptor.AuthenticationInterceptor;
 import edu.handong.csee.histudy.service.BannerService;
 import edu.handong.csee.histudy.service.DiscordService;
 import edu.handong.csee.histudy.service.JwtService;
+import edu.handong.csee.histudy.service.command.BannerCommand;
 import io.jsonwebtoken.Claims;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
@@ -81,7 +84,7 @@ class BannerAdminControllerTest {
         new MockMultipartFile("image", "banner.png", "image/png", "banner".getBytes());
     BannerDto.AdminBannerInfo info = createAdminBannerInfo(1L);
 
-    when(bannerService.createBanner(any())).thenReturn(info);
+    when(bannerService.createBanner(any(BannerCommand.class))).thenReturn(info);
 
     // When & Then
     mockMvc
@@ -95,6 +98,16 @@ class BannerAdminControllerTest {
         .andExpect(status().isCreated())
         .andExpect(content().contentType("application/json"))
         .andExpect(jsonPath("$.id").value(1L));
+
+    ArgumentCaptor<BannerCommand> commandCaptor = ArgumentCaptor.forClass(BannerCommand.class);
+    verify(bannerService).createBanner(commandCaptor.capture());
+    BannerCommand command = commandCaptor.getValue();
+    assertThat(command.label()).isEqualTo("Main Banner");
+    assertThat(command.redirectUrl()).isEqualTo("https://example.com");
+    assertThat(command.active()).isTrue();
+    assertThat(command.image().originalFilename()).isEqualTo("banner.png");
+    assertThat(command.image().contentType()).isEqualTo("image/png");
+    assertThat(command.image().content()).isEqualTo("banner".getBytes());
   }
 
   @Test
@@ -146,7 +159,7 @@ class BannerAdminControllerTest {
         new MockMultipartFile("image", "banner2.png", "image/png", "banner-2".getBytes());
     BannerDto.AdminBannerInfo info = createAdminBannerInfo(2L);
 
-    when(bannerService.updateBanner(eq(2L), any())).thenReturn(info);
+    when(bannerService.updateBanner(eq(2L), any(BannerCommand.class))).thenReturn(info);
 
     MockHttpServletRequestBuilder requestBuilder =
         multipart("/api/admin/banners/{bannerId}", 2L)
@@ -165,6 +178,16 @@ class BannerAdminControllerTest {
         .andExpect(status().isOk())
         .andExpect(content().contentType("application/json"))
         .andExpect(jsonPath("$.id").value(2L));
+
+    ArgumentCaptor<BannerCommand> commandCaptor = ArgumentCaptor.forClass(BannerCommand.class);
+    verify(bannerService).updateBanner(eq(2L), commandCaptor.capture());
+    BannerCommand command = commandCaptor.getValue();
+    assertThat(command.label()).isEqualTo("Updated Banner");
+    assertThat(command.redirectUrl()).isNull();
+    assertThat(command.active()).isNull();
+    assertThat(command.image().originalFilename()).isEqualTo("banner2.png");
+    assertThat(command.image().contentType()).isEqualTo("image/png");
+    assertThat(command.image().content()).isEqualTo("banner-2".getBytes());
   }
 
   @Test

--- a/src/test/java/edu/handong/csee/histudy/controller/BannerAdminControllerTest.java
+++ b/src/test/java/edu/handong/csee/histudy/controller/BannerAdminControllerTest.java
@@ -17,6 +17,7 @@ import edu.handong.csee.histudy.service.DiscordService;
 import edu.handong.csee.histudy.service.JwtService;
 import edu.handong.csee.histudy.service.command.BannerCommand;
 import io.jsonwebtoken.Claims;
+import java.io.IOException;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -108,6 +109,67 @@ class BannerAdminControllerTest {
     assertThat(command.image().originalFilename()).isEqualTo("banner.png");
     assertThat(command.image().contentType()).isEqualTo("image/png");
     assertThat(command.image().content()).isEqualTo("banner".getBytes());
+  }
+
+  @Test
+  void 빈_이미지는_서비스_명령에서_이미지없음으로_변환한다() throws Exception {
+    // Given
+    Claims claims = mock(Claims.class);
+    when(claims.get("rol", String.class)).thenReturn(Role.ADMIN.name());
+
+    MockMultipartFile emptyImage =
+        new MockMultipartFile("image", "banner.png", "image/png", new byte[0]);
+    when(bannerService.createBanner(any(BannerCommand.class))).thenReturn(createAdminBannerInfo(1L));
+
+    // When
+    mockMvc
+        .perform(
+            multipart("/api/admin/banners")
+                .file(emptyImage)
+                .param("label", "Main Banner")
+                .requestAttr("claims", claims))
+        .andExpect(status().isCreated());
+
+    // Then
+    ArgumentCaptor<BannerCommand> commandCaptor = ArgumentCaptor.forClass(BannerCommand.class);
+    verify(bannerService).createBanner(commandCaptor.capture());
+    assertThat(commandCaptor.getValue().image()).isNull();
+  }
+
+  @Test
+  void 제한크기를_초과한_이미지는_내용을_읽기전에_거부한다() throws Exception {
+    // Given
+    Claims claims = mock(Claims.class);
+    when(claims.get("rol", String.class)).thenReturn(Role.ADMIN.name());
+
+    MockMultipartFile oversizedImage =
+        new MockMultipartFile("image", "banner.png", "image/png", new byte[0]) {
+          @Override
+          public boolean isEmpty() {
+            return false;
+          }
+
+          @Override
+          public long getSize() {
+            return 5L * 1024 * 1024 + 1;
+          }
+
+          @Override
+          public byte[] getBytes() throws IOException {
+            throw new AssertionError("oversized image content should not be read");
+          }
+        };
+
+    // When Then
+    mockMvc
+        .perform(
+            multipart("/api/admin/banners")
+                .file(oversizedImage)
+                .param("label", "Main Banner")
+                .requestAttr("claims", claims))
+        .andExpect(status().isBadRequest());
+
+    verifyNoInteractions(bannerService);
   }
 
   @Test

--- a/src/test/java/edu/handong/csee/histudy/service/BannerServiceTest.java
+++ b/src/test/java/edu/handong/csee/histudy/service/BannerServiceTest.java
@@ -3,11 +3,12 @@ package edu.handong.csee.histudy.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import edu.handong.csee.histudy.controller.form.BannerForm;
 import edu.handong.csee.histudy.domain.Banner;
 import edu.handong.csee.histudy.dto.BannerDto;
 import edu.handong.csee.histudy.exception.BannerNotFoundException;
 import edu.handong.csee.histudy.exception.MissingParameterException;
+import edu.handong.csee.histudy.service.command.BannerCommand;
+import edu.handong.csee.histudy.service.command.BannerImage;
 import edu.handong.csee.histudy.service.repository.fake.FakeBannerRepository;
 import edu.handong.csee.histudy.util.ImagePathMapper;
 import java.awt.image.BufferedImage;
@@ -19,7 +20,6 @@ import javax.imageio.ImageIO;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.util.ReflectionTestUtils;
 
 class BannerServiceTest {
@@ -115,15 +115,15 @@ class BannerServiceTest {
   void 새로운_배너를_등록하면_다음_노출순서로_저장된다() throws Exception {
     // Given
     bannerRepository.save(existingBanner);
-    BannerForm form =
-        new BannerForm(
+    BannerCommand command =
+        new BannerCommand(
             "  Spring Banner  ",
             "https://example.com/banner",
             true,
-            new MockMultipartFile("image", "banner.png", "image/png", bannerPngBytes));
+            new BannerImage("banner.png", "image/png", bannerPngBytes));
 
     // When
-    BannerDto.AdminBannerInfo result = bannerService.createBanner(form);
+    BannerDto.AdminBannerInfo result = bannerService.createBanner(command);
 
     // Then
     assertThat(result.getLabel()).isEqualTo("Spring Banner");
@@ -131,15 +131,46 @@ class BannerServiceTest {
     assertThat(bannerRepository.findAll()).hasSize(2);
     Path storedImage = tempDir.resolve(result.getImageUrl().replace("https://histudy.handong.edu/images/", ""));
     assertThat(Files.exists(storedImage)).isTrue();
+    assertThat(Files.readAllBytes(storedImage)).isEqualTo(bannerPngBytes);
   }
 
   @Test
   void 이미지_없이_배너를_등록하면_예외가_발생한다() {
     // Given
-    BannerForm form = new BannerForm("Banner", "https://example.com/banner", true, null);
+    BannerCommand command = new BannerCommand("Banner", "https://example.com/banner", true, null);
 
     // When Then
-    assertThatThrownBy(() -> bannerService.createBanner(form))
+    assertThatThrownBy(() -> bannerService.createBanner(command))
+        .isInstanceOf(MissingParameterException.class);
+  }
+
+  @Test
+  void 이미지가_아닌_내용으로_배너를_등록하면_예외가_발생한다() {
+    // Given
+    BannerCommand command =
+        new BannerCommand(
+            "Banner",
+            "https://example.com/banner",
+            true,
+            new BannerImage("banner.png", "image/png", "not-an-image".getBytes()));
+
+    // When Then
+    assertThatThrownBy(() -> bannerService.createBanner(command))
+        .isInstanceOf(MissingParameterException.class);
+  }
+
+  @Test
+  void 제한크기를_초과한_이미지로_배너를_등록하면_예외가_발생한다() {
+    // Given
+    BannerCommand command =
+        new BannerCommand(
+            "Banner",
+            "https://example.com/banner",
+            true,
+            new BannerImage("banner.png", "image/png", new byte[5 * 1024 * 1024 + 1]));
+
+    // When Then
+    assertThatThrownBy(() -> bannerService.createBanner(command))
         .isInstanceOf(MissingParameterException.class);
   }
 
@@ -148,17 +179,18 @@ class BannerServiceTest {
     // Given
     BannerDto.AdminBannerInfo created =
         bannerService.createBanner(
-            new BannerForm(
+            new BannerCommand(
                 "Original",
                 "https://example.com/original",
                 true,
-                new MockMultipartFile("image", "banner.png", "image/png", bannerPngBytes)));
+                new BannerImage("banner.png", "image/png", bannerPngBytes)));
     String originalImageUrl = created.getImageUrl();
 
     // When
     BannerDto.AdminBannerInfo updated =
         bannerService.updateBanner(
-            created.getId(), new BannerForm("Updated", "https://example.com/updated", false, null));
+            created.getId(),
+            new BannerCommand("Updated", "https://example.com/updated", false, null));
 
     // Then
     assertThat(updated.getLabel()).isEqualTo("Updated");
@@ -233,10 +265,10 @@ class BannerServiceTest {
   @Test
   void 존재하지_않는_배너를_업데이트하면_예외가_발생한다() {
     // Given
-    BannerForm form = new BannerForm("Updated", "https://example.com/updated", true, null);
+    BannerCommand command = new BannerCommand("Updated", "https://example.com/updated", true, null);
 
     // When Then
-    assertThatThrownBy(() -> bannerService.updateBanner(999L, form))
+    assertThatThrownBy(() -> bannerService.updateBanner(999L, command))
         .isInstanceOf(BannerNotFoundException.class);
   }
 

--- a/src/test/java/edu/handong/csee/histudy/service/command/BannerImageTest.java
+++ b/src/test/java/edu/handong/csee/histudy/service/command/BannerImageTest.java
@@ -1,0 +1,23 @@
+package edu.handong.csee.histudy.service.command;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class BannerImageTest {
+
+  @Test
+  void 이미지내용은_생성시점과_조회시점에_방어적으로복사한다() {
+    // Given
+    byte[] source = "banner".getBytes();
+    BannerImage image = new BannerImage("banner.png", "image/png", source);
+
+    // When
+    source[0] = 'X';
+    byte[] exposed = image.content();
+    exposed[1] = 'Y';
+
+    // Then
+    assertThat(image.content()).isEqualTo("banner".getBytes());
+  }
+}


### PR DESCRIPTION
1. `BannerCommand`와 `BannerImage`를 추가해 배너 생성·수정 서비스 입력을 HTTP 요청 객체와 분리

> 서비스 계층이 컨트롤러 폼이나 Spring 웹 타입을 알지 않도록 하면서도 현재의 단순한 레이어드 구조를 유지하기 위한 변경입니다.

2. 컨트롤러에서 `BannerForm`과 `MultipartFile`을 서비스 중립 입력으로 변환하고 빈 파일·초과 크기를 사전 정규화

> HTTP 및 멀티파트 처리 책임을 API 경계에 한정하고, 5MB 초과 파일은 바이트 배열을 만들기 전에 거부해 서비스 경계 분리로 인한 메모리 사용 회귀도 방지했습니다.

3. 이미지 크기·형식 검증, 파일명 생성, 저장 및 트랜잭션 연계 정리 동작을 기존 서비스에 유지

> 이번 단계의 목적은 입력 경계 정리이므로 파일 포트·어댑터를 추가하지 않고 기존 동작과 책임 범위를 보존했습니다.

4. 서비스에서 컨트롤러 패키지로 향하는 레거시 의존 기준선을 0건으로 갱신

> 제거한 나쁜 연결이 이후 변경에서 다시 생기지 않도록 레이어 의존성 테스트로 현재 경계를 고정했습니다.

5. 컨트롤러 변환, 빈 파일 정규화, 크기 사전 검증, 이미지 방어적 복사 및 저장 결과 테스트 보강

> 타입 교체 과정에서 HTTP 입력값이나 이미지 바이트가 유실·변조되지 않고, 제한 초과 파일의 내용을 읽지 않으면서 기존 검증 규칙이 유지되는지 확인하기 위한 회귀 테스트입니다.
