### PR TITLE
매칭 규칙을 도메인 정책으로 분리

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,6 +14,7 @@
 - `service`: 비즈니스 로직과 오케스트레이션
 - `repository`, `repository/jpa`, `repository/impl`: 영속성과 조회 로직
 - `domain`: JPA 엔티티와 엔티티에 가까운 도메인 동작
+- `matching/domain`: 저장소나 Spring에 의존하지 않는 친구·과목 우선 매칭 규칙
 - `config`, `interceptor`, `jwt`: 인증과 요청 파이프라인 구성
 - `exception`, `util`: 공통 예외와 유틸리티
 

--- a/docs/domain.md
+++ b/docs/domain.md
@@ -45,7 +45,9 @@ JWT 인터셉터가 요청에 claims를 넣은 뒤, 컨트롤러가 `Role.isAuth
 
 ## 매칭 규칙
 
-`TeamService.matchTeam()`는 현재 학기에 대해 두 단계로 실행됩니다.
+`matching.domain.MatchingPolicy`는 현재 학기의 미배정 신청자를 대상으로 두 단계 규칙을
+순서대로 적용합니다. `TeamService.matchTeam()`는 현재 학기와 미배정 신청자를 조회하고 정책 결과를
+저장하는 기존 진입점으로 유지됩니다.
 
 1. 친구 우선 매칭
    아직 미배정 상태인 신청자 사이의 수락된 친구 요청을 사용합니다.

--- a/src/main/java/edu/handong/csee/histudy/matching/domain/MatchingPolicy.java
+++ b/src/main/java/edu/handong/csee/histudy/matching/domain/MatchingPolicy.java
@@ -1,0 +1,141 @@
+package edu.handong.csee.histudy.matching.domain;
+
+import edu.handong.csee.histudy.domain.AcademicTerm;
+import edu.handong.csee.histudy.domain.Course;
+import edu.handong.csee.histudy.domain.PreferredCourse;
+import edu.handong.csee.histudy.domain.Priority;
+import edu.handong.csee.histudy.domain.StudyApplicant;
+import edu.handong.csee.histudy.domain.StudyGroup;
+import edu.handong.csee.histudy.domain.StudyPartnerRequest;
+import edu.handong.csee.histudy.domain.User;
+import edu.handong.csee.histudy.util.DFS;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class MatchingPolicy {
+
+  private static final int MIN_FRIEND_GROUP_SIZE = 2;
+  private static final int MIN_COURSE_GROUP_SIZE = 3;
+  private static final int MAX_COURSE_GROUP_SIZE = 5;
+
+  public List<StudyGroup> match(
+      List<StudyApplicant> applicants, AcademicTerm academicTerm, int firstGroupTag) {
+    if (applicants.isEmpty()) {
+      return List.of();
+    }
+
+    AtomicInteger nextGroupTag = new AtomicInteger(firstGroupTag);
+    List<StudyGroup> groups = new ArrayList<>();
+    groups.addAll(groupByFriends(applicants, nextGroupTag, academicTerm));
+    groups.addAll(groupByCoursePreference(applicants, nextGroupTag, academicTerm));
+    return List.copyOf(groups);
+  }
+
+  private List<StudyGroup> groupByFriends(
+      List<StudyApplicant> applicants,
+      AtomicInteger nextGroupTag,
+      AcademicTerm academicTerm) {
+    Map<StudyApplicant, List<StudyApplicant>> friendshipMap = buildFriendshipMap(applicants);
+
+    return new DFS<>(friendshipMap, MIN_FRIEND_GROUP_SIZE)
+        .execute().stream()
+            .map(
+                friends ->
+                    StudyGroup.of(nextGroupTag.getAndIncrement(), academicTerm, friends))
+            .toList();
+  }
+
+  private Map<StudyApplicant, List<StudyApplicant>> buildFriendshipMap(
+      List<StudyApplicant> applicants) {
+    Map<User, StudyApplicant> userToApplicant =
+        applicants.stream().collect(Collectors.toMap(StudyApplicant::getUser, Function.identity()));
+
+    return applicants.stream()
+        .filter(applicant -> !applicant.hasStudyGroup())
+        .flatMap(applicant -> applicant.getPartnerRequests().stream())
+        .filter(StudyPartnerRequest::isAccepted)
+        .filter(request -> userToApplicant.containsKey(request.getReceiver()))
+        .collect(
+            Collectors.groupingBy(
+                StudyPartnerRequest::getSender,
+                Collectors.mapping(
+                    request -> userToApplicant.get(request.getReceiver()), Collectors.toList())));
+  }
+
+  private List<StudyGroup> groupByCoursePreference(
+      List<StudyApplicant> applicants,
+      AtomicInteger nextGroupTag,
+      AcademicTerm academicTerm) {
+    List<PreferredCourse> coursePreferences =
+        applicants.stream()
+            .filter(applicant -> !applicant.hasStudyGroup())
+            .flatMap(applicant -> applicant.getPreferredCourses().stream())
+            .sorted(
+                Comparator.comparingInt(PreferredCourse::getPriority)
+                    .thenComparing(preference -> preference.getCourse().getCourseId()))
+            .toList();
+
+    Map<Priority, Map<Course, List<StudyApplicant>>> priorityCourseMap = new LinkedHashMap<>();
+    coursePreferences.forEach(
+        preference -> {
+          Priority priority = Priority.of(preference.getPriority());
+          Course course = preference.getCourse();
+
+          priorityCourseMap
+              .computeIfAbsent(priority, ignored -> new LinkedHashMap<>())
+              .computeIfAbsent(course, ignored -> new ArrayList<>())
+              .add(preference.getApplicant());
+        });
+
+    return priorityCourseMap.values().stream()
+        .flatMap(courseMap -> courseMap.values().stream())
+        .map(
+            bucket ->
+                bucket.stream().filter(applicant -> !applicant.hasStudyGroup()).toList())
+        .map(
+            remaining ->
+                groupBySize(
+                    remaining,
+                    nextGroupTag,
+                    academicTerm,
+                    0,
+                    MIN_COURSE_GROUP_SIZE,
+                    MAX_COURSE_GROUP_SIZE))
+        .flatMap(Collection::stream)
+        .toList();
+  }
+
+  private List<StudyGroup> groupBySize(
+      List<StudyApplicant> applicants,
+      AtomicInteger nextGroupTag,
+      AcademicTerm academicTerm,
+      int startIndex,
+      int minSize,
+      int maxSize) {
+    int remaining = applicants.size() - startIndex;
+    if (remaining < minSize) {
+      return List.of();
+    }
+
+    int endIndex = startIndex + Math.min(remaining, maxSize);
+    StudyGroup group =
+        StudyGroup.of(
+            nextGroupTag.getAndIncrement(),
+            academicTerm,
+            applicants.subList(startIndex, endIndex));
+
+    List<StudyGroup> groups = new ArrayList<>();
+    groups.add(group);
+    groups.addAll(
+        groupBySize(
+            applicants, nextGroupTag, academicTerm, endIndex, minSize, maxSize));
+    return groups;
+  }
+}

--- a/src/main/java/edu/handong/csee/histudy/matching/domain/MatchingPolicy.java
+++ b/src/main/java/edu/handong/csee/histudy/matching/domain/MatchingPolicy.java
@@ -10,11 +10,11 @@ import edu.handong.csee.histudy.domain.StudyPartnerRequest;
 import edu.handong.csee.histudy.domain.User;
 import edu.handong.csee.histudy.util.DFS;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -27,6 +27,8 @@ public class MatchingPolicy {
 
   public List<StudyGroup> match(
       List<StudyApplicant> applicants, AcademicTerm academicTerm, int firstGroupTag) {
+    Objects.requireNonNull(applicants, "applicants must not be null");
+    Objects.requireNonNull(academicTerm, "academicTerm must not be null");
     if (applicants.isEmpty()) {
       return List.of();
     }
@@ -94,48 +96,41 @@ public class MatchingPolicy {
               .add(preference.getApplicant());
         });
 
-    return priorityCourseMap.values().stream()
-        .flatMap(courseMap -> courseMap.values().stream())
-        .map(
-            bucket ->
-                bucket.stream().filter(applicant -> !applicant.hasStudyGroup()).toList())
-        .map(
-            remaining ->
-                groupBySize(
-                    remaining,
-                    nextGroupTag,
-                    academicTerm,
-                    0,
-                    MIN_COURSE_GROUP_SIZE,
-                    MAX_COURSE_GROUP_SIZE))
-        .flatMap(Collection::stream)
-        .toList();
+    List<StudyGroup> groups = new ArrayList<>();
+    for (Map<Course, List<StudyApplicant>> courseMap : priorityCourseMap.values()) {
+      for (List<StudyApplicant> bucket : courseMap.values()) {
+        List<StudyApplicant> remaining =
+            bucket.stream().filter(applicant -> !applicant.hasStudyGroup()).toList();
+        groups.addAll(
+            groupBySize(
+                remaining,
+                nextGroupTag,
+                academicTerm,
+                MIN_COURSE_GROUP_SIZE,
+                MAX_COURSE_GROUP_SIZE));
+      }
+    }
+    return groups;
   }
 
   private List<StudyGroup> groupBySize(
       List<StudyApplicant> applicants,
       AtomicInteger nextGroupTag,
       AcademicTerm academicTerm,
-      int startIndex,
       int minSize,
       int maxSize) {
-    int remaining = applicants.size() - startIndex;
-    if (remaining < minSize) {
-      return List.of();
-    }
-
-    int endIndex = startIndex + Math.min(remaining, maxSize);
-    StudyGroup group =
-        StudyGroup.of(
-            nextGroupTag.getAndIncrement(),
-            academicTerm,
-            applicants.subList(startIndex, endIndex));
-
     List<StudyGroup> groups = new ArrayList<>();
-    groups.add(group);
-    groups.addAll(
-        groupBySize(
-            applicants, nextGroupTag, academicTerm, endIndex, minSize, maxSize));
+    int startIndex = 0;
+    while (applicants.size() - startIndex >= minSize) {
+      int remaining = applicants.size() - startIndex;
+      int endIndex = startIndex + Math.min(remaining, maxSize);
+      groups.add(
+          StudyGroup.of(
+              nextGroupTag.getAndIncrement(),
+              academicTerm,
+              applicants.subList(startIndex, endIndex)));
+      startIndex = endIndex;
+    }
     return groups;
   }
 }

--- a/src/main/java/edu/handong/csee/histudy/service/TeamService.java
+++ b/src/main/java/edu/handong/csee/histudy/service/TeamService.java
@@ -4,12 +4,11 @@ import edu.handong.csee.histudy.domain.*;
 import edu.handong.csee.histudy.dto.*;
 import edu.handong.csee.histudy.exception.NoCurrentTermFoundException;
 import edu.handong.csee.histudy.exception.UserNotFoundException;
+import edu.handong.csee.histudy.matching.domain.MatchingPolicy;
 import edu.handong.csee.histudy.repository.*;
 import edu.handong.csee.histudy.repository.StudyApplicantRepository;
-import edu.handong.csee.histudy.util.DFS;
 import edu.handong.csee.histudy.util.ImagePathMapper;
 import java.util.*;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +26,7 @@ public class TeamService {
   private final StudyReportRepository studyReportRepository;
 
   private final ImagePathMapper imagePathMapper;
+  private final MatchingPolicy matchingPolicy = new MatchingPolicy();
 
   public List<TeamDto> getTeams(String email) {
     AcademicTerm currentTerm =
@@ -133,113 +133,11 @@ public class TeamService {
     }
 
     int latestGroupTag = studyGroupRepository.countMaxTag(current).orElse(0);
-    AtomicInteger tag = new AtomicInteger(latestGroupTag + 1);
-
-    // First matching - friend-based
-    List<StudyGroup> friendGroups = groupByFriends(allApplicants, tag, current);
-    List<StudyGroup> allMatchedGroups = new ArrayList<>(friendGroups);
-
-    // Second matching - course-based with priority (remaining unassigned applicants)
-    List<StudyGroup> courseFirstGroups = groupByCoursePreference(allApplicants, tag, current);
-    allMatchedGroups.addAll(courseFirstGroups);
+    List<StudyGroup> allMatchedGroups =
+        matchingPolicy.match(allApplicants, current, latestGroupTag + 1);
 
     if (!allMatchedGroups.isEmpty()) {
       studyGroupRepository.saveAll(allMatchedGroups);
     }
-  }
-
-  protected List<StudyGroup> groupByFriends(
-      List<StudyApplicant> applicants, AtomicInteger tag, AcademicTerm current) {
-    if (applicants.isEmpty()) {
-      return new ArrayList<>();
-    }
-    Map<StudyApplicant, List<StudyApplicant>> friendshipMap = buildFriendshipMap(applicants);
-    int minGroupSize = 2;
-
-    return new DFS<>(friendshipMap, minGroupSize)
-        .execute().stream()
-            .map(friends -> StudyGroup.of(tag.getAndIncrement(), current, friends))
-            .toList();
-  }
-
-  private Map<StudyApplicant, List<StudyApplicant>> buildFriendshipMap(
-      List<StudyApplicant> applicants) {
-    Map<User, StudyApplicant> userToApplicant =
-        applicants.stream().collect(Collectors.toMap(StudyApplicant::getUser, Function.identity()));
-
-    return applicants.stream()
-        .filter(applicant -> !applicant.hasStudyGroup())
-        .flatMap(applicant -> applicant.getPartnerRequests().stream())
-        .filter(StudyPartnerRequest::isAccepted)
-        .filter(request -> userToApplicant.containsKey(request.getReceiver()))
-        .collect(
-            Collectors.groupingBy(
-                StudyPartnerRequest::getSender,
-                Collectors.mapping(
-                    r -> userToApplicant.get(r.getReceiver()), Collectors.toList())));
-  }
-
-  protected List<StudyGroup> groupByCoursePreference(
-      List<StudyApplicant> applicants, AtomicInteger tag, AcademicTerm current) {
-    if (applicants.isEmpty()) {
-      return new ArrayList<>();
-    }
-    List<PreferredCourse> coursePreferences =
-        applicants.stream()
-            .filter(a -> !a.hasStudyGroup())
-            .flatMap(a -> a.getPreferredCourses().stream())
-            .sorted(
-                Comparator.comparingInt(PreferredCourse::getPriority)
-                    .thenComparing(p -> p.getCourse().getCourseId()))
-            .toList();
-
-    Map<Priority, Map<Course, List<StudyApplicant>>> priorityCourseMap = new LinkedHashMap<>();
-
-    coursePreferences.forEach(
-        pc -> {
-          Priority priority = Priority.of(pc.getPriority());
-          Course course = pc.getCourse();
-
-          priorityCourseMap
-              .computeIfAbsent(priority, p -> new LinkedHashMap<>())
-              .computeIfAbsent(course, c -> new ArrayList<>())
-              .add(pc.getApplicant());
-        });
-
-    int minGroupSize = 3;
-    int maxGroupSize = 5;
-
-    return priorityCourseMap.values().stream()
-        .flatMap(courseMap -> courseMap.values().stream())
-        .map(_applicants -> _applicants.stream().filter(a -> !a.hasStudyGroup()).toList())
-        .map(remaining -> groupBySize(remaining, tag, current, 0, minGroupSize, maxGroupSize))
-        .flatMap(Collection::stream)
-        .toList();
-  }
-
-  private List<StudyGroup> groupBySize(
-      List<StudyApplicant> applicants,
-      AtomicInteger tag,
-      AcademicTerm current,
-      int startIndex,
-      int minSize,
-      int maxSize) {
-    List<StudyGroup> results = new ArrayList<>();
-    int remaining = applicants.size() - startIndex;
-
-    if (remaining < minSize) {
-      return results;
-    }
-    int endIndex = startIndex + Math.min(remaining, maxSize);
-    List<StudyApplicant> groupedApplicants = applicants.subList(startIndex, endIndex);
-
-    StudyGroup studyGroup = StudyGroup.of(tag.getAndIncrement(), current, groupedApplicants);
-    results.add(studyGroup);
-
-    List<StudyGroup> studyGroups =
-        groupBySize(applicants, tag, current, endIndex, minSize, maxSize);
-    results.addAll(studyGroups);
-
-    return results;
   }
 }

--- a/src/test/java/edu/handong/csee/histudy/architecture/LayerDependencyTest.java
+++ b/src/test/java/edu/handong/csee/histudy/architecture/LayerDependencyTest.java
@@ -17,6 +17,8 @@ class LayerDependencyTest {
   private static final Path CONTROLLER_SOURCE_DIRECTORY =
       MAIN_SOURCE_DIRECTORY.resolve("controller");
   private static final Path SERVICE_SOURCE_DIRECTORY = MAIN_SOURCE_DIRECTORY.resolve("service");
+  private static final Path MATCHING_DOMAIN_SOURCE_DIRECTORY =
+      MAIN_SOURCE_DIRECTORY.resolve("matching/domain");
   private static final String CONTROLLER_PACKAGE_PREFIX =
       "edu.handong.csee.histudy.controller.";
   private static final String REPOSITORY_PACKAGE_PREFIX =
@@ -54,6 +56,29 @@ class LayerDependencyTest {
 
     // Then
     assertThat(forbiddenDependencies).isEmpty();
+  }
+
+  @Test
+  void 매칭도메인은_Spring에_의존하지_않는다() throws IOException {
+    // Given
+    List<Path> matchingDomainSources;
+    try (Stream<Path> paths = Files.walk(MATCHING_DOMAIN_SOURCE_DIRECTORY)) {
+      matchingDomainSources =
+          paths.filter(path -> path.toString().endsWith(".java")).sorted().toList();
+    }
+
+    // When
+    List<String> springDependencies =
+        matchingDomainSources.stream()
+            .flatMap(
+                source ->
+                    readLines(source)
+                        .filter(line -> isSourceCodeLine(line) && line.contains("org.springframework."))
+                        .map(line -> source + ": " + line))
+            .toList();
+
+    // Then
+    assertThat(springDependencies).isEmpty();
   }
 
   @Test

--- a/src/test/java/edu/handong/csee/histudy/matching/domain/MatchingPolicyTest.java
+++ b/src/test/java/edu/handong/csee/histudy/matching/domain/MatchingPolicyTest.java
@@ -1,0 +1,123 @@
+package edu.handong.csee.histudy.matching.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import edu.handong.csee.histudy.domain.AcademicTerm;
+import edu.handong.csee.histudy.domain.Course;
+import edu.handong.csee.histudy.domain.Role;
+import edu.handong.csee.histudy.domain.StudyApplicant;
+import edu.handong.csee.histudy.domain.StudyGroup;
+import edu.handong.csee.histudy.domain.StudyPartnerRequest;
+import edu.handong.csee.histudy.domain.TermType;
+import edu.handong.csee.histudy.domain.User;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class MatchingPolicyTest {
+
+  private final AcademicTerm currentTerm =
+      AcademicTerm.builder().academicYear(2025).semester(TermType.SPRING).isCurrent(true).build();
+  private final Course primaryCourse = createCourse(1L, "자료구조");
+  private final Course secondaryCourse = createCourse(2L, "운영체제");
+  private final MatchingPolicy matchingPolicy = new MatchingPolicy();
+
+  @Test
+  void 매칭하면_친구를_먼저_배정하고_남은_신청자를_과목으로_배정한다() {
+    // Given
+    User friendOne = createUser(1);
+    User friendTwo = createUser(2);
+    StudyApplicant friendOneApplicant =
+        StudyApplicant.of(currentTerm, friendOne, List.of(friendTwo), List.of(primaryCourse));
+    StudyApplicant friendTwoApplicant =
+        StudyApplicant.of(currentTerm, friendTwo, List.of(), List.of(primaryCourse));
+    friendOneApplicant.changeStatusIfReceivedBy(friendTwo, StudyPartnerRequest::accept);
+
+    List<StudyApplicant> courseApplicants =
+        List.of(
+            createApplicant(3, primaryCourse),
+            createApplicant(4, primaryCourse),
+            createApplicant(5, primaryCourse));
+    List<StudyApplicant> leftoverApplicants =
+        List.of(createApplicant(6, secondaryCourse), createApplicant(7, secondaryCourse));
+
+    List<StudyApplicant> applicants = new ArrayList<>();
+    applicants.add(friendOneApplicant);
+    applicants.add(friendTwoApplicant);
+    applicants.addAll(courseApplicants);
+    applicants.addAll(leftoverApplicants);
+
+    // When
+    List<StudyGroup> result = matchingPolicy.match(applicants, currentTerm, 10);
+
+    // Then
+    assertThat(result).extracting(StudyGroup::getTag).containsExactly(10, 11);
+    assertThat(result).extracting(group -> group.getMembers().size()).containsExactly(2, 3);
+    assertThat(result.get(0).getMembers())
+        .extracting(applicant -> applicant.getUser().getEmail())
+        .containsExactlyInAnyOrder(friendOne.getEmail(), friendTwo.getEmail());
+    assertThat(result.get(1).getMembers()).containsExactlyInAnyOrderElementsOf(courseApplicants);
+    assertThat(leftoverApplicants).allMatch(applicant -> !applicant.hasStudyGroup());
+  }
+
+  @Test
+  void 과목이_같은_신청자가_여덟명이면_다섯명과_세명_그룹으로_나눈다() {
+    // Given
+    List<StudyApplicant> applicants =
+        List.of(
+            createApplicant(1, primaryCourse),
+            createApplicant(2, primaryCourse),
+            createApplicant(3, primaryCourse),
+            createApplicant(4, primaryCourse),
+            createApplicant(5, primaryCourse),
+            createApplicant(6, primaryCourse),
+            createApplicant(7, primaryCourse),
+            createApplicant(8, primaryCourse));
+
+    // When
+    List<StudyGroup> result = matchingPolicy.match(applicants, currentTerm, 4);
+
+    // Then
+    assertThat(result).extracting(StudyGroup::getTag).containsExactly(4, 5);
+    assertThat(result).extracting(group -> group.getMembers().size()).containsExactly(5, 3);
+    assertThat(applicants).allMatch(StudyApplicant::hasStudyGroup);
+  }
+
+  @Test
+  void 신청자가_없으면_그룹을_만들지_않는다() {
+    // Given
+
+    // When
+    List<StudyGroup> result = matchingPolicy.match(List.of(), currentTerm, 1);
+
+    // Then
+    assertThat(result).isEmpty();
+  }
+
+  private StudyApplicant createApplicant(int sequence, Course course) {
+    return StudyApplicant.of(currentTerm, createUser(sequence), List.of(), List.of(course));
+  }
+
+  private User createUser(int sequence) {
+    return User.builder()
+        .sub("sub-" + sequence)
+        .sid("2223%04d".formatted(sequence))
+        .email("user%d@histudy.com".formatted(sequence))
+        .name("User" + sequence)
+        .role(Role.USER)
+        .build();
+  }
+
+  private Course createCourse(Long courseId, String name) {
+    Course course =
+        Course.builder()
+            .name(name)
+            .code("CSEE" + courseId)
+            .professor("Professor")
+            .academicTerm(currentTerm)
+            .build();
+    ReflectionTestUtils.setField(course, "courseId", courseId);
+    return course;
+  }
+}

--- a/src/test/java/edu/handong/csee/histudy/matching/domain/MatchingPolicyTest.java
+++ b/src/test/java/edu/handong/csee/histudy/matching/domain/MatchingPolicyTest.java
@@ -1,6 +1,7 @@
 package edu.handong.csee.histudy.matching.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import edu.handong.csee.histudy.domain.AcademicTerm;
 import edu.handong.csee.histudy.domain.Course;
@@ -93,6 +94,50 @@ class MatchingPolicyTest {
 
     // Then
     assertThat(result).isEmpty();
+  }
+
+  @Test
+  void 신청자목록이_null이면_명시적인_예외가_발생한다() {
+    // Given
+
+    // When Then
+    assertThatThrownBy(() -> matchingPolicy.match(null, currentTerm, 1))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("applicants must not be null");
+  }
+
+  @Test
+  void 과목이_같은_신청자가_여섯명이면_다섯명을_배정하고_한명은_남긴다() {
+    // Given
+    List<StudyApplicant> applicants = createApplicants(6);
+
+    // When
+    List<StudyGroup> result = matchingPolicy.match(applicants, currentTerm, 1);
+
+    // Then
+    assertThat(result).singleElement().satisfies(group -> assertThat(group.getMembers()).hasSize(5));
+    assertThat(applicants).filteredOn(applicant -> !applicant.hasStudyGroup()).hasSize(1);
+  }
+
+  @Test
+  void 과목이_같은_신청자가_일곱명이면_다섯명을_배정하고_두명은_남긴다() {
+    // Given
+    List<StudyApplicant> applicants = createApplicants(7);
+
+    // When
+    List<StudyGroup> result = matchingPolicy.match(applicants, currentTerm, 1);
+
+    // Then
+    assertThat(result).singleElement().satisfies(group -> assertThat(group.getMembers()).hasSize(5));
+    assertThat(applicants).filteredOn(applicant -> !applicant.hasStudyGroup()).hasSize(2);
+  }
+
+  private List<StudyApplicant> createApplicants(int count) {
+    List<StudyApplicant> applicants = new ArrayList<>();
+    for (int sequence = 1; sequence <= count; sequence++) {
+      applicants.add(createApplicant(sequence, primaryCourse));
+    }
+    return applicants;
   }
 
   private StudyApplicant createApplicant(int sequence, Course course) {


### PR DESCRIPTION
1. 친구 우선·과목 우선 그룹 배정 규칙을 `matching.domain.MatchingPolicy`로 추출

> 리포지토리 조율과 핵심 매칭 규칙이 한 서비스에 섞여 있던 구조를 분리해, 복잡한 규칙만 제한적으로 DDD 경계 안에서 보호하려는 변경입니다.

2. `TeamService.matchTeam()`은 현재 학기·미배정 신청자 조회와 그룹 저장만 조율하도록 축소

> 기존 관리자 진입점과 트랜잭션·저장 흐름은 유지하면서 다음 PR에서 애플리케이션 서비스로 옮길 수 있는 분기점을 마련했습니다.

3. 친구 연결 최소 2명, 과목 그룹 3~5명, 친구 우선 후 과목 우선, 연속 태그와 3명 미만 잔여 미배정 규칙을 정책 테스트로 고정

> 코드 이동 과정에서 기존 매칭 순서와 6·7명 버킷의 현재 잔여 인원 처리, 학기별 태그 증가 동작이 바뀌지 않도록 핵심 규칙을 저장소 없는 테스트로 검증합니다.

4. 매칭 정책의 null 전제조건을 명시하고 과목 버킷 순회·그룹 분할을 반복문으로 정리

> 호출 오류를 빈 결과로 숨기지 않으면서 상태 변경 순서를 명확히 하고, 신청자 수에 비례하는 재귀 호출 위험을 제거했습니다.

5. `matching.domain`의 외부 레이어 및 Spring 의존을 패키지 의존 테스트로 차단

> 현재 단계의 경계는 물리 모듈이 아니라 논리 패키지이므로, 접근 제한자만으로 강제할 수 없는 패키지 간 의존 방향을 자동 테스트로 보호합니다.

6. 도메인·아키텍처 문서에 매칭 정책의 현재 책임과 기존 `TeamService` 진입점 역할을 반영

> 실제 코드 구조와 저장소의 기준 문서가 어긋나지 않도록 이번 PR에서 생긴 책임 이동만 문서화했습니다.
