### PR TITLE
매칭 유스케이스 조율을 애플리케이션 계층으로 분리

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,6 +14,7 @@
 - `service`: 비즈니스 로직과 오케스트레이션
 - `repository`, `repository/jpa`, `repository/impl`: 영속성과 조회 로직
 - `domain`: JPA 엔티티와 엔티티에 가까운 도메인 동작
+- `matching/application`: 매칭 유스케이스의 트랜잭션과 저장소 조율
 - `matching/domain`: 저장소나 Spring에 의존하지 않는 친구·과목 우선 매칭 규칙
 - `config`, `interceptor`, `jwt`: 인증과 요청 파이프라인 구성
 - `exception`, `util`: 공통 예외와 유틸리티

--- a/docs/domain.md
+++ b/docs/domain.md
@@ -46,8 +46,8 @@ JWT 인터셉터가 요청에 claims를 넣은 뒤, 컨트롤러가 `Role.isAuth
 ## 매칭 규칙
 
 `matching.domain.MatchingPolicy`는 현재 학기의 미배정 신청자를 대상으로 두 단계 규칙을
-순서대로 적용합니다. `TeamService.matchTeam()`는 현재 학기와 미배정 신청자를 조회하고 정책 결과를
-저장하는 기존 진입점으로 유지됩니다.
+순서대로 적용합니다. `matching.application.MatchingApplicationService`는 현재 학기와 미배정 신청자를
+조회하고 정책 결과를 저장합니다. `TeamService.matchTeam()`는 기존 호출자를 위한 파사드로 유지됩니다.
 
 1. 친구 우선 매칭
    아직 미배정 상태인 신청자 사이의 수락된 친구 요청을 사용합니다.

--- a/src/main/java/edu/handong/csee/histudy/matching/application/MatchingApplicationService.java
+++ b/src/main/java/edu/handong/csee/histudy/matching/application/MatchingApplicationService.java
@@ -1,0 +1,44 @@
+package edu.handong.csee.histudy.matching.application;
+
+import edu.handong.csee.histudy.domain.AcademicTerm;
+import edu.handong.csee.histudy.domain.StudyApplicant;
+import edu.handong.csee.histudy.domain.StudyGroup;
+import edu.handong.csee.histudy.exception.NoCurrentTermFoundException;
+import edu.handong.csee.histudy.matching.domain.MatchingPolicy;
+import edu.handong.csee.histudy.repository.AcademicTermRepository;
+import edu.handong.csee.histudy.repository.StudyApplicantRepository;
+import edu.handong.csee.histudy.repository.StudyGroupRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MatchingApplicationService {
+
+  private final AcademicTermRepository academicTermRepository;
+  private final StudyApplicantRepository studyApplicantRepository;
+  private final StudyGroupRepository studyGroupRepository;
+  private final MatchingPolicy matchingPolicy = new MatchingPolicy();
+
+  public void match() {
+    AcademicTerm currentTerm =
+        academicTermRepository.findCurrentSemester().orElseThrow(NoCurrentTermFoundException::new);
+    List<StudyApplicant> applicants =
+        studyApplicantRepository.findUnassignedApplicants(currentTerm);
+
+    if (applicants.isEmpty()) {
+      return;
+    }
+
+    int latestGroupTag = studyGroupRepository.countMaxTag(currentTerm).orElse(0);
+    List<StudyGroup> matchedGroups =
+        matchingPolicy.match(applicants, currentTerm, latestGroupTag + 1);
+
+    if (!matchedGroups.isEmpty()) {
+      studyGroupRepository.saveAll(matchedGroups);
+    }
+  }
+}

--- a/src/main/java/edu/handong/csee/histudy/service/TeamService.java
+++ b/src/main/java/edu/handong/csee/histudy/service/TeamService.java
@@ -4,7 +4,7 @@ import edu.handong.csee.histudy.domain.*;
 import edu.handong.csee.histudy.dto.*;
 import edu.handong.csee.histudy.exception.NoCurrentTermFoundException;
 import edu.handong.csee.histudy.exception.UserNotFoundException;
-import edu.handong.csee.histudy.matching.domain.MatchingPolicy;
+import edu.handong.csee.histudy.matching.application.MatchingApplicationService;
 import edu.handong.csee.histudy.repository.*;
 import edu.handong.csee.histudy.repository.StudyApplicantRepository;
 import edu.handong.csee.histudy.util.ImagePathMapper;
@@ -26,7 +26,7 @@ public class TeamService {
   private final StudyReportRepository studyReportRepository;
 
   private final ImagePathMapper imagePathMapper;
-  private final MatchingPolicy matchingPolicy = new MatchingPolicy();
+  private final MatchingApplicationService matchingApplicationService;
 
   public List<TeamDto> getTeams(String email) {
     AcademicTerm currentTerm =
@@ -124,20 +124,6 @@ public class TeamService {
   }
 
   public void matchTeam() {
-    AcademicTerm current =
-        academicTermRepository.findCurrentSemester().orElseThrow(NoCurrentTermFoundException::new);
-    List<StudyApplicant> allApplicants = studyApplicantRepository.findUnassignedApplicants(current);
-
-    if (allApplicants.isEmpty()) {
-      return;
-    }
-
-    int latestGroupTag = studyGroupRepository.countMaxTag(current).orElse(0);
-    List<StudyGroup> allMatchedGroups =
-        matchingPolicy.match(allApplicants, current, latestGroupTag + 1);
-
-    if (!allMatchedGroups.isEmpty()) {
-      studyGroupRepository.saveAll(allMatchedGroups);
-    }
+    matchingApplicationService.match();
   }
 }

--- a/src/test/java/edu/handong/csee/histudy/architecture/LayerDependencyTest.java
+++ b/src/test/java/edu/handong/csee/histudy/architecture/LayerDependencyTest.java
@@ -19,6 +19,8 @@ class LayerDependencyTest {
   private static final Path SERVICE_SOURCE_DIRECTORY = MAIN_SOURCE_DIRECTORY.resolve("service");
   private static final Path MATCHING_DOMAIN_SOURCE_DIRECTORY =
       MAIN_SOURCE_DIRECTORY.resolve("matching/domain");
+  private static final Path MATCHING_APPLICATION_SOURCE_DIRECTORY =
+      MAIN_SOURCE_DIRECTORY.resolve("matching/application");
   private static final String CONTROLLER_PACKAGE_PREFIX =
       "edu.handong.csee.histudy.controller.";
   private static final String REPOSITORY_PACKAGE_PREFIX =
@@ -79,6 +81,34 @@ class LayerDependencyTest {
 
     // Then
     assertThat(springDependencies).isEmpty();
+  }
+
+  @Test
+  void 매칭애플리케이션은_API와_레거시서비스에_의존하지_않는다() throws IOException {
+    // Given
+    List<Path> matchingApplicationSources;
+    try (Stream<Path> paths = Files.walk(MATCHING_APPLICATION_SOURCE_DIRECTORY)) {
+      matchingApplicationSources =
+          paths.filter(path -> path.toString().endsWith(".java")).sorted().toList();
+    }
+
+    // When
+    List<String> forbiddenDependencies =
+        matchingApplicationSources.stream()
+            .flatMap(
+                source ->
+                    readLines(source)
+                        .filter(
+                            line ->
+                                isSourceCodeLine(line)
+                                    && (line.contains(CONTROLLER_PACKAGE_PREFIX)
+                                        || line.contains("edu.handong.csee.histudy.dto.")
+                                        || line.contains("edu.handong.csee.histudy.service.")))
+                        .map(line -> source + ": " + line))
+            .toList();
+
+    // Then
+    assertThat(forbiddenDependencies).isEmpty();
   }
 
   @Test

--- a/src/test/java/edu/handong/csee/histudy/matching/application/MatchingApplicationServiceTest.java
+++ b/src/test/java/edu/handong/csee/histudy/matching/application/MatchingApplicationServiceTest.java
@@ -1,0 +1,141 @@
+package edu.handong.csee.histudy.matching.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import edu.handong.csee.histudy.domain.AcademicTerm;
+import edu.handong.csee.histudy.domain.Course;
+import edu.handong.csee.histudy.domain.Role;
+import edu.handong.csee.histudy.domain.StudyApplicant;
+import edu.handong.csee.histudy.domain.StudyGroup;
+import edu.handong.csee.histudy.domain.StudyPartnerRequest;
+import edu.handong.csee.histudy.domain.TermType;
+import edu.handong.csee.histudy.domain.User;
+import edu.handong.csee.histudy.exception.NoCurrentTermFoundException;
+import edu.handong.csee.histudy.service.repository.fake.FakeAcademicTermRepository;
+import edu.handong.csee.histudy.service.repository.fake.FakeStudyApplicationRepository;
+import edu.handong.csee.histudy.service.repository.fake.FakeStudyGroupRepository;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class MatchingApplicationServiceTest {
+
+  private final AcademicTerm currentTerm =
+      AcademicTerm.builder().academicYear(2025).semester(TermType.SPRING).isCurrent(true).build();
+  private final Course primaryCourse = createCourse(1L, "자료구조");
+  private final Course secondaryCourse = createCourse(2L, "운영체제");
+
+  private FakeAcademicTermRepository academicTermRepository;
+  private FakeStudyApplicationRepository studyApplicantRepository;
+  private FakeStudyGroupRepository studyGroupRepository;
+  private MatchingApplicationService matchingApplicationService;
+
+  @BeforeEach
+  void setUp() {
+    academicTermRepository = new FakeAcademicTermRepository();
+    studyApplicantRepository = new FakeStudyApplicationRepository();
+    studyGroupRepository = new FakeStudyGroupRepository();
+    matchingApplicationService =
+        new MatchingApplicationService(
+            academicTermRepository, studyApplicantRepository, studyGroupRepository);
+  }
+
+  @Test
+  void 그룹을_자동_배정하면_친구_우선과_과목_우선_정책결과를_저장한다() {
+    // Given
+    academicTermRepository.save(currentTerm);
+    User friendOne = createUser(1);
+    User friendTwo = createUser(2);
+    StudyApplicant friendOneApplicant =
+        StudyApplicant.of(currentTerm, friendOne, List.of(friendTwo), List.of(primaryCourse));
+    StudyApplicant friendTwoApplicant =
+        StudyApplicant.of(currentTerm, friendTwo, List.of(), List.of(primaryCourse));
+    friendOneApplicant.changeStatusIfReceivedBy(friendTwo, StudyPartnerRequest::accept);
+
+    List<StudyApplicant> courseApplicants =
+        List.of(
+            createApplicant(3, primaryCourse),
+            createApplicant(4, primaryCourse),
+            createApplicant(5, primaryCourse));
+    List<StudyApplicant> leftoverApplicants =
+        List.of(createApplicant(6, secondaryCourse), createApplicant(7, secondaryCourse));
+
+    List<StudyApplicant> applicants = new ArrayList<>();
+    applicants.add(friendOneApplicant);
+    applicants.add(friendTwoApplicant);
+    applicants.addAll(courseApplicants);
+    applicants.addAll(leftoverApplicants);
+    studyApplicantRepository.saveAll(applicants);
+
+    // When
+    matchingApplicationService.match();
+
+    // Then
+    List<StudyGroup> groups = studyGroupRepository.findAllByAcademicTerm(currentTerm);
+    assertThat(groups).extracting(StudyGroup::getTag).containsExactly(1, 2);
+    assertThat(groups).extracting(group -> group.getMembers().size()).containsExactly(2, 3);
+    assertThat(leftoverApplicants).allMatch(applicant -> !applicant.hasStudyGroup());
+  }
+
+  @Test
+  void 기존_그룹태그가_있으면_다음_번호부터_새_그룹을_저장한다() {
+    // Given
+    academicTermRepository.save(currentTerm);
+    StudyApplicant existingApplicant = createApplicant(1, primaryCourse);
+    studyApplicantRepository.save(existingApplicant);
+    studyGroupRepository.save(StudyGroup.of(7, currentTerm, List.of(existingApplicant)));
+
+    List<StudyApplicant> newApplicants =
+        List.of(
+            createApplicant(2, primaryCourse),
+            createApplicant(3, primaryCourse),
+            createApplicant(4, primaryCourse));
+    studyApplicantRepository.saveAll(newApplicants);
+
+    // When
+    matchingApplicationService.match();
+
+    // Then
+    assertThat(studyGroupRepository.findAllByAcademicTerm(currentTerm))
+        .extracting(StudyGroup::getTag)
+        .containsExactly(7, 8);
+  }
+
+  @Test
+  void 현재_학기_없이_그룹을_자동_배정하면_예외가_발생한다() {
+    // Given
+
+    // When Then
+    assertThatThrownBy(matchingApplicationService::match)
+        .isInstanceOf(NoCurrentTermFoundException.class);
+  }
+
+  private StudyApplicant createApplicant(int sequence, Course course) {
+    return StudyApplicant.of(currentTerm, createUser(sequence), List.of(), List.of(course));
+  }
+
+  private User createUser(int sequence) {
+    return User.builder()
+        .sub("sub-" + sequence)
+        .sid("2223%04d".formatted(sequence))
+        .email("user%d@histudy.com".formatted(sequence))
+        .name("User" + sequence)
+        .role(Role.USER)
+        .build();
+  }
+
+  private Course createCourse(Long courseId, String name) {
+    Course course =
+        Course.builder()
+            .name(name)
+            .code("CSEE" + courseId)
+            .professor("Professor")
+            .academicTerm(currentTerm)
+            .build();
+    ReflectionTestUtils.setField(course, "courseId", courseId);
+    return course;
+  }
+}

--- a/src/test/java/edu/handong/csee/histudy/service/TeamServiceTest.java
+++ b/src/test/java/edu/handong/csee/histudy/service/TeamServiceTest.java
@@ -2,13 +2,14 @@ package edu.handong.csee.histudy.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 import edu.handong.csee.histudy.domain.AcademicTerm;
 import edu.handong.csee.histudy.domain.Course;
 import edu.handong.csee.histudy.domain.Role;
 import edu.handong.csee.histudy.domain.StudyApplicant;
 import edu.handong.csee.histudy.domain.StudyGroup;
-import edu.handong.csee.histudy.domain.StudyPartnerRequest;
 import edu.handong.csee.histudy.domain.StudyReport;
 import edu.handong.csee.histudy.domain.TermType;
 import edu.handong.csee.histudy.domain.User;
@@ -18,6 +19,7 @@ import edu.handong.csee.histudy.dto.TeamRankDto;
 import edu.handong.csee.histudy.dto.TeamReportDto;
 import edu.handong.csee.histudy.dto.UserDto;
 import edu.handong.csee.histudy.exception.NoCurrentTermFoundException;
+import edu.handong.csee.histudy.matching.application.MatchingApplicationService;
 import edu.handong.csee.histudy.service.repository.fake.FakeAcademicTermRepository;
 import edu.handong.csee.histudy.service.repository.fake.FakeStudyApplicationRepository;
 import edu.handong.csee.histudy.service.repository.fake.FakeStudyGroupRepository;
@@ -26,7 +28,6 @@ import edu.handong.csee.histudy.service.repository.fake.FakeUserRepository;
 import edu.handong.csee.histudy.util.ImagePathMapper;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -36,7 +37,6 @@ class TeamServiceTest {
   private final AcademicTerm currentTerm =
       AcademicTerm.builder().academicYear(2025).semester(TermType.SPRING).isCurrent(true).build();
   private final Course commonCourse = createCourse(1L, "자료구조", "CSEE201", "Kim", currentTerm);
-  private final Course secondaryCourse = createCourse(2L, "운영체제", "CSEE301", "Lee", currentTerm);
   private final User memberUser =
       User.builder()
           .sub("sub-1")
@@ -83,6 +83,7 @@ class TeamServiceTest {
   private FakeAcademicTermRepository academicTermRepository;
   private FakeStudyApplicationRepository studyApplicantRepository;
   private FakeStudyReportRepository studyReportRepository;
+  private ImagePathMapper imagePathMapper;
   private TeamService teamService;
 
   @BeforeEach
@@ -92,9 +93,12 @@ class TeamServiceTest {
     academicTermRepository = new FakeAcademicTermRepository();
     studyApplicantRepository = new FakeStudyApplicationRepository();
     studyReportRepository = new FakeStudyReportRepository();
-    ImagePathMapper imagePathMapper = new ImagePathMapper();
+    imagePathMapper = new ImagePathMapper();
     ReflectionTestUtils.setField(imagePathMapper, "origin", "https://histudy.handong.edu");
     ReflectionTestUtils.setField(imagePathMapper, "imageBasePath", "/images");
+    MatchingApplicationService matchingApplicationService =
+        new MatchingApplicationService(
+            academicTermRepository, studyApplicantRepository, studyGroupRepository);
     teamService =
         new TeamService(
             studyGroupRepository,
@@ -102,144 +106,30 @@ class TeamServiceTest {
             academicTermRepository,
             studyApplicantRepository,
             studyReportRepository,
-            imagePathMapper);
+            imagePathMapper,
+            matchingApplicationService);
   }
 
   @Test
-  void 그룹을_자동_배정하면_친구_우선과_과목_우선_규칙으로_배정한다() {
+  void 그룹을_자동_배정하면_매칭애플리케이션서비스에_위임한다() {
     // Given
-    academicTermRepository.save(currentTerm);
-    Course leftoverCourse = secondaryCourse;
-
-    User friendOne =
-        userRepository.save(
-            User.builder()
-                .sub("sub-1")
-                .sid("22230001")
-                .email("friend1@histudy.com")
-                .name("Friend1")
-                .role(Role.USER)
-                .build());
-    User friendTwo =
-        userRepository.save(
-            User.builder()
-                .sub("sub-2")
-                .sid("22230002")
-                .email("friend2@histudy.com")
-                .name("Friend2")
-                .role(Role.USER)
-                .build());
-    User courseOne =
-        userRepository.save(
-            User.builder()
-                .sub("sub-3")
-                .sid("22230003")
-                .email("course1@histudy.com")
-                .name("Course1")
-                .role(Role.USER)
-                .build());
-    User courseTwo =
-        userRepository.save(
-            User.builder()
-                .sub("sub-4")
-                .sid("22230004")
-                .email("course2@histudy.com")
-                .name("Course2")
-                .role(Role.USER)
-                .build());
-    User courseThree =
-        userRepository.save(
-            User.builder()
-                .sub("sub-5")
-                .sid("22230005")
-                .email("course3@histudy.com")
-                .name("Course3")
-                .role(Role.USER)
-                .build());
-    User leftoverOne =
-        userRepository.save(
-            User.builder()
-                .sub("sub-6")
-                .sid("22230006")
-                .email("left1@histudy.com")
-                .name("Left1")
-                .role(Role.USER)
-                .build());
-    User leftoverTwo =
-        userRepository.save(
-            User.builder()
-                .sub("sub-7")
-                .sid("22230007")
-                .email("left2@histudy.com")
-                .name("Left2")
-                .role(Role.USER)
-                .build());
-
-    StudyApplicant friendOneApplicant =
-        StudyApplicant.of(currentTerm, friendOne, List.of(friendTwo), List.of(commonCourse));
-    StudyApplicant friendTwoApplicant =
-        StudyApplicant.of(currentTerm, friendTwo, List.of(friendOne), List.of(commonCourse));
-    friendOneApplicant.changeStatusIfReceivedBy(friendTwo, StudyPartnerRequest::accept);
-    friendTwoApplicant.changeStatusIfReceivedBy(friendOne, StudyPartnerRequest::accept);
-
-    StudyApplicant courseOneApplicant =
-        StudyApplicant.of(currentTerm, courseOne, List.of(), List.of(commonCourse));
-    StudyApplicant courseTwoApplicant =
-        StudyApplicant.of(currentTerm, courseTwo, List.of(), List.of(commonCourse));
-    StudyApplicant courseThreeApplicant =
-        StudyApplicant.of(currentTerm, courseThree, List.of(), List.of(commonCourse));
-    StudyApplicant leftoverOneApplicant =
-        StudyApplicant.of(currentTerm, leftoverOne, List.of(), List.of(leftoverCourse));
-    StudyApplicant leftoverTwoApplicant =
-        StudyApplicant.of(currentTerm, leftoverTwo, List.of(), List.of(leftoverCourse));
-
-    studyApplicantRepository.saveAll(
-        List.of(
-            friendOneApplicant,
-            friendTwoApplicant,
-            courseOneApplicant,
-            courseTwoApplicant,
-            courseThreeApplicant,
-            leftoverOneApplicant,
-            leftoverTwoApplicant));
+    MatchingApplicationService matchingApplicationService =
+        mock(MatchingApplicationService.class);
+    TeamService facade =
+        new TeamService(
+            studyGroupRepository,
+            userRepository,
+            academicTermRepository,
+            studyApplicantRepository,
+            studyReportRepository,
+            imagePathMapper,
+            matchingApplicationService);
 
     // When
-    teamService.matchTeam();
+    facade.matchTeam();
 
     // Then
-    List<StudyGroup> createdGroups = studyGroupRepository.findAllByAcademicTerm(currentTerm);
-    assertThat(createdGroups).hasSize(2);
-    assertThat(createdGroups)
-        .extracting(group -> group.getMembers().size())
-        .containsExactlyInAnyOrder(2, 3);
-    StudyGroup friendGroup =
-        createdGroups.stream()
-            .filter(
-                group ->
-                    group.getMembers().stream()
-                        .anyMatch(
-                            applicant ->
-                                applicant.getUser().getEmail().equals(friendOne.getEmail())))
-            .findFirst()
-            .orElseThrow(() -> new AssertionError("friendOne should belong to a matched group"));
-    assertThat(friendGroup.getMembers())
-        .extracting(applicant -> applicant.getUser().getEmail())
-        .contains(friendTwo.getEmail());
-    assertThat(createdGroups)
-        .anySatisfy(
-            group ->
-                assertThat(
-                        group.getMembers().stream()
-                            .map(applicant -> applicant.getUser().getEmail())
-                            .collect(java.util.stream.Collectors.toSet()))
-                    .containsAll(
-                        Set.of(
-                            courseOne.getEmail(),
-                            courseTwo.getEmail(),
-                            courseThree.getEmail())));
-    assertThat(studyApplicantRepository.findUnassignedApplicants(currentTerm))
-        .extracting(applicant -> applicant.getUser().getEmail())
-        .containsExactlyInAnyOrder("left1@histudy.com", "left2@histudy.com");
+    verify(matchingApplicationService).match();
   }
 
   @Test
@@ -407,15 +297,6 @@ class TeamServiceTest {
     assertThat(result.getReports())
         .extracting(ReportDto.ReportBasic::getTitle)
         .containsExactly("2주차", "1주차");
-  }
-
-  @Test
-  void 현재_학기_없이_그룹을_자동_배정하면_예외가_발생한다() {
-    // Given
-
-    // When Then
-    assertThatThrownBy(() -> teamService.matchTeam())
-        .isInstanceOf(NoCurrentTermFoundException.class);
   }
 
   @Test


### PR DESCRIPTION
1. `matching.application.MatchingApplicationService`를 추가해 매칭 유스케이스 조율을 분리

> 현재 학기 조회, 미배정 신청자 조회, 최대 태그 계산, 도메인 정책 실행, 그룹 저장을 하나의 애플리케이션 유스케이스로 모아 규칙과 저장소 조율의 책임을 구분했습니다.

2. `TeamService.matchTeam()`을 새 애플리케이션 서비스로 위임하는 호환 파사드로 축소

> 아직 `AdminController`가 기존 서비스를 호출하므로 이번 PR에서는 진입점을 유지하고, 다음 PR에서 호출자를 전환한 뒤 파사드를 제거할 수 있게 했습니다.

3. 매칭 결과 저장, 기존 최대 태그 다음 번호 사용, 현재 학기 부재 예외를 애플리케이션 서비스 테스트로 이동

> 정책 자체 테스트와 저장소·트랜잭션 조율 테스트를 분리해 각 계층의 실패 원인과 책임을 명확히 했습니다.

4. `TeamService` 테스트는 매칭 애플리케이션 서비스 위임만 검증하도록 정리

> 파사드가 도메인 규칙을 중복 테스트하지 않고 기존 호출자의 호환 경로만 보장하도록 테스트 책임을 실제 코드 구조에 맞췄습니다.

5. `matching.application`의 API·DTO·레거시 서비스 역방향 의존을 패키지 테스트로 차단

> 애플리케이션 계층은 Spring 트랜잭션과 저장소 계약을 사용할 수 있지만 HTTP 경계나 기존 전역 서비스에 의존하지 않도록 논리 경계를 고정했습니다.

6. 도메인·아키텍처 문서에 애플리케이션 서비스와 `TeamService` 파사드의 현재 역할을 반영

> 단계적 전환 중인 실제 호출 구조를 기준 문서에서 확인할 수 있도록 현재 상태만 갱신했습니다.
