### PR TITLE
관리자 매칭 호출자를 새 유스케이스로 전환

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,6 +25,10 @@
 
 `controller -> service -> repository -> domain`
 
+매칭 유스케이스는 점진적 모듈화가 적용된 첫 경로로 다음과 같이 흐릅니다.
+
+`AdminController -> matching/application -> matching/domain + repository`
+
 유지해야 할 역할 분리는 다음과 같습니다.
 
 - 컨트롤러는 HTTP 요청 바인딩, 응답, 권한 검사를 담당합니다.
@@ -95,7 +99,8 @@
 ## 테스트 구조
 
 - 컨트롤러 테스트: 엔드포인트 동작과 응답 검증
-- 서비스 테스트: 비즈니스 규칙과 매칭 로직
+- 서비스 테스트: 전역 서비스의 비즈니스 동작
+- 매칭 테스트: `matching/domain`의 정책 규칙과 `matching/application`의 유스케이스 조율
 - 리포지토리 테스트: 커스텀 조회 동작
 - `service/repository/fake`: 서비스 테스트용 인메모리 테스트 더블
 - `support`: 공통 테스트 헬퍼

--- a/docs/domain.md
+++ b/docs/domain.md
@@ -47,7 +47,7 @@ JWT 인터셉터가 요청에 claims를 넣은 뒤, 컨트롤러가 `Role.isAuth
 
 `matching.domain.MatchingPolicy`는 현재 학기의 미배정 신청자를 대상으로 두 단계 규칙을
 순서대로 적용합니다. `matching.application.MatchingApplicationService`는 현재 학기와 미배정 신청자를
-조회하고 정책 결과를 저장합니다. `TeamService.matchTeam()`는 기존 호출자를 위한 파사드로 유지됩니다.
+조회하고 정책 결과를 저장하며, 관리자 매칭 API가 이 유스케이스를 직접 호출합니다.
 
 1. 친구 우선 매칭
    아직 미배정 상태인 신청자 사이의 수락된 친구 요청을 사용합니다.

--- a/src/main/java/edu/handong/csee/histudy/controller/AdminController.java
+++ b/src/main/java/edu/handong/csee/histudy/controller/AdminController.java
@@ -7,6 +7,7 @@ import edu.handong.csee.histudy.dto.TeamDto;
 import edu.handong.csee.histudy.dto.TeamReportDto;
 import edu.handong.csee.histudy.dto.UserDto;
 import edu.handong.csee.histudy.exception.ForbiddenException;
+import edu.handong.csee.histudy.matching.application.MatchingApplicationService;
 import edu.handong.csee.histudy.service.AcademicTermService;
 import edu.handong.csee.histudy.service.TeamService;
 import edu.handong.csee.histudy.service.UserService;
@@ -24,6 +25,7 @@ public class AdminController {
   private final TeamService teamService;
   private final UserService userService;
   private final AcademicTermService academicTermService;
+  private final MatchingApplicationService matchingApplicationService;
 
   @GetMapping(value = "/manageGroup")
   public ResponseEntity<List<TeamDto>> getTeams(@RequestAttribute Claims claims) {
@@ -63,7 +65,7 @@ public class AdminController {
   @PostMapping("/team-match")
   public ResponseEntity<Void> matchTeam(@RequestAttribute Claims claims) {
     if (Role.isAuthorized(claims, Role.ADMIN)) {
-      teamService.matchTeam();
+      matchingApplicationService.match();
       return ResponseEntity.status(HttpStatus.CREATED).build();
     }
     throw new ForbiddenException();

--- a/src/main/java/edu/handong/csee/histudy/service/TeamService.java
+++ b/src/main/java/edu/handong/csee/histudy/service/TeamService.java
@@ -4,7 +4,6 @@ import edu.handong.csee.histudy.domain.*;
 import edu.handong.csee.histudy.dto.*;
 import edu.handong.csee.histudy.exception.NoCurrentTermFoundException;
 import edu.handong.csee.histudy.exception.UserNotFoundException;
-import edu.handong.csee.histudy.matching.application.MatchingApplicationService;
 import edu.handong.csee.histudy.repository.*;
 import edu.handong.csee.histudy.repository.StudyApplicantRepository;
 import edu.handong.csee.histudy.util.ImagePathMapper;
@@ -26,7 +25,6 @@ public class TeamService {
   private final StudyReportRepository studyReportRepository;
 
   private final ImagePathMapper imagePathMapper;
-  private final MatchingApplicationService matchingApplicationService;
 
   public List<TeamDto> getTeams(String email) {
     AcademicTerm currentTerm =
@@ -123,7 +121,4 @@ public class TeamService {
     return new TeamRankDto(teams);
   }
 
-  public void matchTeam() {
-    matchingApplicationService.match();
-  }
 }

--- a/src/test/java/edu/handong/csee/histudy/architecture/LayerDependencyTest.java
+++ b/src/test/java/edu/handong/csee/histudy/architecture/LayerDependencyTest.java
@@ -25,6 +25,8 @@ class LayerDependencyTest {
       "edu.handong.csee.histudy.controller.";
   private static final String REPOSITORY_PACKAGE_PREFIX =
       "edu.handong.csee.histudy.repository.";
+  private static final String MATCHING_APPLICATION_PACKAGE_PREFIX =
+      "edu.handong.csee.histudy.matching.application.";
   private static final List<String> LEGACY_SERVICE_CONTROLLER_DEPENDENCIES = List.of();
   private static final List<String> FORBIDDEN_DEPENDENCY_PREFIXES =
       List.of(
@@ -146,6 +148,16 @@ class LayerDependencyTest {
   }
 
   @Test
+  void 전역서비스는_매칭애플리케이션에_의존하지_않는다() throws IOException {
+    // Given When
+    List<String> matchingApplicationDependencies =
+        collectDependencies(SERVICE_SOURCE_DIRECTORY, MATCHING_APPLICATION_PACKAGE_PREFIX);
+
+    // Then
+    assertThat(matchingApplicationDependencies).isEmpty();
+  }
+
+  @Test
   void 같은이름의_서비스소스가_서로다른패키지에있어도_컨트롤러의존을_모두탐지한다(
       @TempDir Path serviceDirectory) throws IOException {
     // Given
@@ -248,8 +260,13 @@ class LayerDependencyTest {
 
   private static List<String> collectControllerDependencies(Path serviceSourceDirectory)
       throws IOException {
+    return collectDependencies(serviceSourceDirectory, CONTROLLER_PACKAGE_PREFIX);
+  }
+
+  private static List<String> collectDependencies(Path sourceDirectory, String packagePrefix)
+      throws IOException {
     List<Path> serviceSources;
-    try (Stream<Path> paths = Files.walk(serviceSourceDirectory)) {
+    try (Stream<Path> paths = Files.walk(sourceDirectory)) {
       serviceSources =
           paths
               .filter(Files::isRegularFile)
@@ -262,10 +279,10 @@ class LayerDependencyTest {
         .flatMap(
             source ->
                 readLines(source)
-                    .filter(LayerDependencyTest::isControllerDependency)
+                    .filter(line -> isSourceCodeLine(line) && line.contains(packagePrefix))
                     .map(
                         line ->
-                            relativeSourcePath(serviceSourceDirectory, source) + ": " + line))
+                            relativeSourcePath(sourceDirectory, source) + ": " + line))
         .toList();
   }
 
@@ -283,10 +300,6 @@ class LayerDependencyTest {
 
   private static boolean isRepositoryDependency(String line) {
     return isSourceCodeLine(line) && line.contains(REPOSITORY_PACKAGE_PREFIX);
-  }
-
-  private static boolean isControllerDependency(String line) {
-    return isSourceCodeLine(line) && line.contains(CONTROLLER_PACKAGE_PREFIX);
   }
 
   private static boolean isSourceCodeLine(String line) {

--- a/src/test/java/edu/handong/csee/histudy/controller/AdminControllerTest.java
+++ b/src/test/java/edu/handong/csee/histudy/controller/AdminControllerTest.java
@@ -16,6 +16,7 @@ import edu.handong.csee.histudy.dto.TeamDto;
 import edu.handong.csee.histudy.dto.TeamReportDto;
 import edu.handong.csee.histudy.dto.UserDto;
 import edu.handong.csee.histudy.interceptor.AuthenticationInterceptor;
+import edu.handong.csee.histudy.matching.application.MatchingApplicationService;
 import edu.handong.csee.histudy.service.AcademicTermService;
 import edu.handong.csee.histudy.service.DiscordService;
 import edu.handong.csee.histudy.service.JwtService;
@@ -44,6 +45,8 @@ class AdminControllerTest {
 
   @MockitoBean private TeamService teamService;
 
+  @MockitoBean private MatchingApplicationService matchingApplicationService;
+
   @MockitoBean private UserService userService;
 
   @MockitoBean private AcademicTermService academicTermService;
@@ -58,7 +61,11 @@ class AdminControllerTest {
 
     mockMvc =
         MockMvcBuilders.standaloneSetup(
-                new AdminController(teamService, userService, academicTermService))
+                new AdminController(
+                    teamService,
+                    userService,
+                    academicTermService,
+                    matchingApplicationService))
             .setControllerAdvice(new ExceptionController(discordService))
             .addInterceptors(authenticationInterceptor)
             .build();
@@ -107,11 +114,26 @@ class AdminControllerTest {
   void 관리자가_그룹매칭실행시_성공() throws Exception {
     Claims claims = adminClaims("admin@test.com");
 
-    doNothing().when(teamService).matchTeam();
+    doNothing().when(matchingApplicationService).match();
 
     mockMvc
         .perform(post("/api/admin/team-match").requestAttr("claims", claims))
         .andExpect(status().isCreated());
+
+    verify(matchingApplicationService).match();
+  }
+
+  @Test
+  void 일반유저가_그룹매칭실행시_실패() throws Exception {
+    // Given
+    Claims claims = userClaims("user@test.com");
+
+    // When Then
+    mockMvc
+        .perform(post("/api/admin/team-match").requestAttr("claims", claims))
+        .andExpect(status().isForbidden());
+
+    verifyNoInteractions(matchingApplicationService);
   }
 
   @Test

--- a/src/test/java/edu/handong/csee/histudy/service/TeamServiceTest.java
+++ b/src/test/java/edu/handong/csee/histudy/service/TeamServiceTest.java
@@ -2,8 +2,6 @@ package edu.handong.csee.histudy.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 
 import edu.handong.csee.histudy.domain.AcademicTerm;
 import edu.handong.csee.histudy.domain.Course;
@@ -19,7 +17,6 @@ import edu.handong.csee.histudy.dto.TeamRankDto;
 import edu.handong.csee.histudy.dto.TeamReportDto;
 import edu.handong.csee.histudy.dto.UserDto;
 import edu.handong.csee.histudy.exception.NoCurrentTermFoundException;
-import edu.handong.csee.histudy.matching.application.MatchingApplicationService;
 import edu.handong.csee.histudy.service.repository.fake.FakeAcademicTermRepository;
 import edu.handong.csee.histudy.service.repository.fake.FakeStudyApplicationRepository;
 import edu.handong.csee.histudy.service.repository.fake.FakeStudyGroupRepository;
@@ -96,9 +93,6 @@ class TeamServiceTest {
     imagePathMapper = new ImagePathMapper();
     ReflectionTestUtils.setField(imagePathMapper, "origin", "https://histudy.handong.edu");
     ReflectionTestUtils.setField(imagePathMapper, "imageBasePath", "/images");
-    MatchingApplicationService matchingApplicationService =
-        new MatchingApplicationService(
-            academicTermRepository, studyApplicantRepository, studyGroupRepository);
     teamService =
         new TeamService(
             studyGroupRepository,
@@ -106,30 +100,7 @@ class TeamServiceTest {
             academicTermRepository,
             studyApplicantRepository,
             studyReportRepository,
-            imagePathMapper,
-            matchingApplicationService);
-  }
-
-  @Test
-  void 그룹을_자동_배정하면_매칭애플리케이션서비스에_위임한다() {
-    // Given
-    MatchingApplicationService matchingApplicationService =
-        mock(MatchingApplicationService.class);
-    TeamService facade =
-        new TeamService(
-            studyGroupRepository,
-            userRepository,
-            academicTermRepository,
-            studyApplicantRepository,
-            studyReportRepository,
-            imagePathMapper,
-            matchingApplicationService);
-
-    // When
-    facade.matchTeam();
-
-    // Then
-    verify(matchingApplicationService).match();
+            imagePathMapper);
   }
 
   @Test


### PR DESCRIPTION
1. 관리자 매칭 API가 `MatchingApplicationService`를 직접 호출하도록 전환

> #216과 #217에서 분리한 도메인 정책과 애플리케이션 유스케이스를 실제 HTTP 진입점에 연결해 새 논리 모듈을 기본 실행 경로로 완성했습니다.

2. `TeamService.matchTeam()`과 `MatchingApplicationService` 파사드 의존 제거

> 모든 호출자가 전환된 뒤 임시 파사드를 제거한다는 점진적 모듈화 원칙에 따라 중복 진입점과 불필요한 서비스 간 연결을 정리했습니다.

3. 관리자·비관리자 매칭 API 테스트를 새 호출 대상 기준으로 갱신

> 관리자는 매칭 유스케이스를 정확히 한 번 실행하고, 비관리자는 권한 검사에서 차단되어 애플리케이션 서비스가 호출되지 않음을 검증합니다.

4. 전역 `service` 패키지에서 `matching.application`으로 향하는 의존 기준선을 0건으로 고정

> 매칭 모듈이 다시 레거시 서비스 뒤의 파사드로 숨지 않도록 제거된 연결을 패키지 의존 테스트로 보호합니다.

5. 도메인·아키텍처 문서를 최종 매칭 호출 흐름과 테스트 책임에 맞게 갱신

> 최종 경로인 `AdminController -> matching/application -> matching/domain + repository`와 계층별 테스트 책임을 저장소 기준 문서에 반영했습니다.
